### PR TITLE
Attempt to fix Travis build errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ node_js:
   - "5"
 before_install:
   - npm -g install npm@'>=3'
+# this is from the below libxmljs test, just to confirm it's installed correctly
   - $CXX --version
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,17 @@ node_js:
   - "5"
 before_install:
   - npm -g install npm@'>=3'
+  - $CXX --version
 cache:
   directories:
     - node_modules
+# ensure libxmljs can get compiled
+env:
+    - CXX=g++-4.8
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - g++-4.8
+sudo: false


### PR DESCRIPTION
Travis is failing on merely installing libxmljs.

Copying build configuration from libxmljs to try and get project building and unit-testing again successfully.