### PR TITLE
Fix syntax error due to use of non-transformable ES6 "new.target"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ node_js:
   - "stable"
   - "6"
   - "5"
+  - "4"
+  - "0.12"
 before_install:
   - npm -g install npm@'>=3'
 # this is from the below libxmljs test, just to confirm it's installed correctly

--- a/lib/park.js
+++ b/lib/park.js
@@ -68,8 +68,8 @@ class Park {
      */
     constructor(options = {}) {
         // can only construct actual parks, not the park object itself
-        //  see https://stackoverflow.com/questions/29480569/does-ecmascript-6-have-a-convention-for-abstract-classes
-        if (new.target === Park) {
+        //  see http://ilikekillnerds.com/2015/06/abstract-classes-in-javascript/
+        if (this.constructor === Park) {
             throw new TypeError("Cannot create Park object directly, only park implementations of Park");
         }
 

--- a/lib/test.js
+++ b/lib/test.js
@@ -19,7 +19,7 @@ try {
         it("should not create the park base successfully", function(done) {
             try {
                 parkBase = new Park();
-                assert(parkBase, "parkBase should not successfully construct");
+                assert(!parkBase, "parkBase should not successfully construct");
             } catch (err) {
                 done();
             }
@@ -129,8 +129,18 @@ try {
         it("should have an array of parks as .AllParks", function() {
             assert(Array.isArray(themeparks.AllParks), ".AllParks should be an array of all the parks available");
         });
+
         it("should have an object of parks as .Parks", function() {
             assert(themeparks.Parks.constructor === {}.constructor, ".Parks should be an object of available parks");
+
+            for(var i in themeparks.Parks) {
+                if(!themeparks.Parks.hasOwnProperty(i)) {
+                    continue;
+                }
+
+                var park = new themeparks.Parks[i]();
+                assert(!!park, 'Park ' + i + ' failed to initialize.');
+            }
         });
 
         for (var i = 0, park; park = themeparks.AllParks[i++];) {


### PR DESCRIPTION
"new.target" is used to ensure that the base class cannot be instantiated directly, but this is an ES6 feature new to Node.js v5.0.0 that cannot be transformed directly by Babel v6 (https://github.com/babel/babel/issues/1088) and results in a syntax error in versions of Node.js <5.0.0. This change fixes the issue using this.constructor and ensures that the script properly runs on older versions of Node.js when Babel is used to build the dist files.

This also adjusts the Travis CI Node.JS versions to include Node.JS 4 and 0.12, which are listed as supported in the package.json file.

Fixes #45