### PR TITLE
Get all universal opening times published for the next year

### DIFF
--- a/lib/universal/index.js
+++ b/lib/universal/index.js
@@ -183,7 +183,7 @@ class UniversalPark extends Park {
     FetchOpeningTimes() {
         return new Promise(function(resolve, reject) {
             // pick a date 1 month from now (in middle/lowest/highest form MM/DD/YYYY, because I don't know)
-            var hoursEndDate = Moment().add(1, "months").format("MM/DD/YYYY");
+            var hoursEndDate = Moment().add(12, "months").format("MM/DD/YYYY");
 
             this.GetAPIUrl({
                 url: api_baseURL + `venues/${this[s_parkID]}/hours`,
@@ -194,7 +194,7 @@ class UniversalPark extends Park {
             }).then(function(body) {
                 if (!body || !body.length) return reject("No venue hour data found from Universal API");
 
-                // find next 10 days opening times and insert into our schedule
+                // find all published opening times for the next year and insert into our schedule
                 for (var i = 0, day; day = body[i++];) {
                     this.Schedule.SetDate({
                         // for ease, we'll just parse the Unix timestamp


### PR DESCRIPTION
Universal API's now return wait times greater than one month, added this change to get all available wait times for the next year. 

The API returns all available park opening times and no more so it will only add valid dates to the schedule. 

A minor change but a useful one to be able to see all available opening dates.