### PR TITLE
Prevent access token expiring edge case

### DIFF
--- a/lib/disney/index.js
+++ b/lib/disney/index.js
@@ -95,7 +95,7 @@ class WaltDisneyWorldPark extends Park {
      * Get our current access token
      */
     GetAccessToken() {
-        var ttlExpiresIn;
+        var expiresIn;
         return this.Cache.Wrap("accesstoken", function() {
             return new Promise(function(resolve, reject) {
                 // request a fresh access token
@@ -116,16 +116,22 @@ class WaltDisneyWorldPark extends Park {
                     }
 
                     // parse expires_in into an int
-                    ttlExpiresIn = parseInt(body.expires_in, 10);
+                    var ttlExpiresIn = parseInt(body.expires_in, 10);
 
-                    this.Log(`Fetched new WDW access_token ${body.access_token}, expires in ${body.expires_in}`);
+                    // The ttlExpiresIn is the maximum time the access_token is valid. 
+                    // It's possible for the token to be given back just moments before
+                    // it is invalid. Therefore we should force the ttl value in the
+                    // cache lower than this value so requests don't fail.
+                    var expiresIn = Math.ceil(ttlExpiresIn * .75);
+                    
+                    this.Log(`Fetched new WDW access_token ${body.access_token}, expires in ${body.expires_in}, caching for a maximum of ${expiresIn}`);
 
                     // return our new access token
                     return resolve(body.access_token);
                 }.bind(this), reject);
             }.bind(this));
         }.bind(this), function() {
-            return ttlExpiresIn;
+            return expiresIn;
         }.bind(this));
     }
 


### PR DESCRIPTION
It is possible for the access token to expire just as it is
retrieved from the cache and then fails during the request.
Prevent this from occurring by indicating to the cache that
the ttl is lower than the actual token ttl.