### PR TITLE
Update project dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "themeparks",
-    "version": "4.3.1",
+    "version": "4.4.0",
     "lockfileVersion": 1,
     "dependencies": {
         "@types/node": {
@@ -769,21 +769,15 @@
             "dev": true,
             "optional": true
         },
-        "catharsis": {
-            "version": "0.8.8",
-            "resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.8.8.tgz",
-            "integrity": "sha1-aTR59DqsVJ2Aa9c+kkzQ2USVGgY=",
-            "dev": true
-        },
         "chalk": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
             "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg="
         },
         "cheerio": {
-            "version": "1.0.0-rc.1",
-            "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.1.tgz",
-            "integrity": "sha1-KvNzOeq3E+9rcs3pjO+mcrh2Qf4="
+            "version": "1.0.0-rc.2",
+            "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.2.tgz",
+            "integrity": "sha1-S59TqBsn5NXawxwP/Qz6A8xoMNs="
         },
         "chokidar": {
             "version": "1.7.0",
@@ -815,11 +809,6 @@
             "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
             "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
             "dev": true
-        },
-        "code-point-at": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-            "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
         },
         "combined-stream": {
             "version": "1.0.5",
@@ -1079,21 +1068,39 @@
             "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
         },
         "eslint": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.0.0.tgz",
-            "integrity": "sha1-cnfAFDf99B3M0WjVqg5Jt1yh8mA=",
+            "version": "4.4.1",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.4.1.tgz",
+            "integrity": "sha1-mc1+r8/8ov+Zpcj18qR01jZLS9M=",
             "dev": true,
             "dependencies": {
                 "acorn": {
-                    "version": "5.0.3",
-                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.0.3.tgz",
-                    "integrity": "sha1-xGDfCEkUY/AozLguqzcwvwEIez0=",
+                    "version": "5.1.1",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.1.1.tgz",
+                    "integrity": "sha512-vOk6uEMctu0vQrvuSqFdJyqj1Q0S5VTDL79qtjo+DhRr+1mmaD+tluFSCZqhvi/JUhXSzoZN2BhtstaPEeE8cw==",
+                    "dev": true
+                },
+                "ajv": {
+                    "version": "5.2.2",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.2.tgz",
+                    "integrity": "sha1-R8aNaehvXZUxA7AHSpQw3GPaXjk=",
                     "dev": true
                 },
                 "espree": {
-                    "version": "3.4.3",
-                    "resolved": "https://registry.npmjs.org/espree/-/espree-3.4.3.tgz",
-                    "integrity": "sha1-KRC1zNSc6JPC//+qtP2LOjG4I3Q=",
+                    "version": "3.5.0",
+                    "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.0.tgz",
+                    "integrity": "sha1-mDWGJb3QVYYeon4oZ+pyn69GPY0=",
+                    "dev": true
+                },
+                "esprima": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+                    "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+                    "dev": true
+                },
+                "js-yaml": {
+                    "version": "3.9.1",
+                    "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.9.1.tgz",
+                    "integrity": "sha512-CbcG379L1e+mWBnLvHWWeLs8GyV/EMw862uLI3c+GxVyDHWZcjZinwuBd3iW2pgxgIlksW/1vNJa4to+RvDOww==",
                     "dev": true
                 }
             }
@@ -1102,18 +1109,6 @@
             "version": "3.7.1",
             "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
             "integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
-            "dev": true
-        },
-        "espree": {
-            "version": "3.1.7",
-            "resolved": "https://registry.npmjs.org/espree/-/espree-3.1.7.tgz",
-            "integrity": "sha1-/V3ux2qXpRIKnNOnyxF3oJI7EdI=",
-            "dev": true
-        },
-        "esprima": {
-            "version": "3.1.3",
-            "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
-            "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
             "dev": true
         },
         "esquery": {
@@ -1190,6 +1185,12 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
             "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
+            "dev": true
+        },
+        "fast-deep-equal": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
+            "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8=",
             "dev": true
         },
         "fast-levenshtein": {
@@ -1328,6 +1329,12 @@
             "dev": true,
             "optional": true
         },
+        "functional-red-black-tree": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+            "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+            "dev": true
+        },
         "gauge": {
             "version": "2.7.4",
             "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
@@ -1350,18 +1357,6 @@
                     "optional": true
                 }
             }
-        },
-        "generate-function": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-            "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
-            "dev": true
-        },
-        "generate-object-property": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-            "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
-            "dev": true
         },
         "get-stdin": {
             "version": "4.0.1",
@@ -1668,12 +1663,6 @@
             "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
             "dev": true
         },
-        "is-my-json-valid": {
-            "version": "2.16.0",
-            "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
-            "integrity": "sha1-8Hndm/2uZe4gOKrorLyGqxCeNpM=",
-            "dev": true
-        },
         "is-number": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
@@ -1722,12 +1711,6 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
             "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
-            "dev": true
-        },
-        "is-property": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-            "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
             "dev": true
         },
         "is-redirect": {
@@ -1799,18 +1782,6 @@
             "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
             "dev": true
         },
-        "js-yaml": {
-            "version": "3.8.4",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.8.4.tgz",
-            "integrity": "sha1-UgtFZPhlc7qWZir4Woyvp7S1pvY=",
-            "dev": true
-        },
-        "js2xmlparser": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/js2xmlparser/-/js2xmlparser-1.0.0.tgz",
-            "integrity": "sha1-WhcPLo1kds5FQF4EgjJCUTeC/jA=",
-            "dev": true
-        },
         "jsbn": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
@@ -1825,15 +1796,33 @@
             "dev": true
         },
         "jsdoc": {
-            "version": "3.4.3",
-            "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-3.4.3.tgz",
-            "integrity": "sha1-5XQNYUXGgfZnnmwXeDqI292XzNM=",
+            "version": "3.5.4",
+            "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-3.5.4.tgz",
+            "integrity": "sha512-VmTw0J+2L16IxAe0JSDSAcH0F+DbZxaj8wN1AjHtKMQU/hO0ciIl5ZE93XqrrFIbknobuqHKJCXZj6+Hk57MjA==",
             "dev": true,
             "dependencies": {
-                "bluebird": {
-                    "version": "3.4.7",
-                    "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
-                    "integrity": "sha1-9y12C+Cbf3bQjtj66Ysomo0F+rM=",
+                "babylon": {
+                    "version": "7.0.0-beta.19",
+                    "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.19.tgz",
+                    "integrity": "sha512-Vg0C9s/REX6/WIXN37UKpv5ZhRi6A4pjHlpkE34+8/a6c2W1Q692n3hmc+SZG5lKRnaExLUbxtJ1SVT+KaCQ/A==",
+                    "dev": true
+                },
+                "catharsis": {
+                    "version": "0.8.9",
+                    "resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.8.9.tgz",
+                    "integrity": "sha1-mMyJDKZS3S7w5ws3klMQ/56Q/Is=",
+                    "dev": true
+                },
+                "js2xmlparser": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/js2xmlparser/-/js2xmlparser-3.0.0.tgz",
+                    "integrity": "sha1-P7YOqgicVED5MZ9RdgzNB+JJlzM=",
+                    "dev": true
+                },
+                "klaw": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/klaw/-/klaw-2.0.0.tgz",
+                    "integrity": "sha1-WcEo4Nxc5BAgEVEZTuucv4WGUPY=",
                     "dev": true
                 }
             }
@@ -1850,6 +1839,12 @@
             "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
             "dev": true,
             "optional": true
+        },
+        "json-schema-traverse": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+            "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+            "dev": true
         },
         "json-stable-stringify": {
             "version": "1.0.1",
@@ -1880,12 +1875,6 @@
             "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
             "dev": true
         },
-        "jsonpointer": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
-            "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
-            "dev": true
-        },
         "jsprim": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
@@ -1906,12 +1895,6 @@
             "version": "3.2.2",
             "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-            "dev": true
-        },
-        "klaw": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
-            "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
             "dev": true
         },
         "levn": {
@@ -2122,27 +2105,15 @@
             "dev": true
         },
         "mocha": {
-            "version": "3.4.2",
-            "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.4.2.tgz",
-            "integrity": "sha1-0O9NMyEm2/GNDWQMmzgt1IvpdZQ=",
+            "version": "3.5.0",
+            "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.5.0.tgz",
+            "integrity": "sha512-pIU2PJjrPYvYRqVpjXzj76qltO9uBYI7woYAMoxbSefsa+vqAfptjoeevd6bUgwD0mPIO+hv9f7ltvsNreL2PA==",
             "dev": true,
             "dependencies": {
-                "debug": {
-                    "version": "2.6.0",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.0.tgz",
-                    "integrity": "sha1-vFlryr52F/Edn6FTYe3tVgi4SZs=",
-                    "dev": true
-                },
                 "glob": {
                     "version": "7.1.1",
                     "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
                     "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
-                    "dev": true
-                },
-                "ms": {
-                    "version": "0.7.2",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
-                    "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U=",
                     "dev": true
                 },
                 "supports-color": {
@@ -2188,9 +2159,9 @@
             "dev": true
         },
         "needle": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/needle/-/needle-1.6.0.tgz",
-            "integrity": "sha1-9SpYWJchIWGOAC+OY4TK2sItYk8="
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/needle/-/needle-2.0.0.tgz",
+            "integrity": "sha1-MuKYVJUtxmsIKT1xfoovhQCyy8M="
         },
         "nested-error-stacks": {
             "version": "2.0.0",
@@ -3043,9 +3014,9 @@
             "dev": true
         },
         "tz-lookup": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/tz-lookup/-/tz-lookup-6.1.0.tgz",
-            "integrity": "sha1-irr1tCBwfq4AOuKXqZ+ChqkKuWA=",
+            "version": "6.1.1",
+            "resolved": "https://registry.npmjs.org/tz-lookup/-/tz-lookup-6.1.1.tgz",
+            "integrity": "sha1-PMkKSZE7xPk4CRol0KX5sbEIjqg=",
             "dev": true
         },
         "uid-number": {
@@ -3161,6 +3132,12 @@
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
             "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+            "dev": true
+        },
+        "xmlcreate": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/xmlcreate/-/xmlcreate-1.0.2.tgz",
+            "integrity": "sha1-+mv3YqYKQT+z3Y9LA8WyaSONMI8=",
             "dev": true
         },
         "xtend": {

--- a/package.json
+++ b/package.json
@@ -9,10 +9,10 @@
     "dependencies": {
         "bluebird": "^3.5.0",
         "cache-manager": "^2.4.0",
-        "cheerio": "^1.0.0-rc.1",
+        "cheerio": "^1.0.0-rc.2",
         "cookie": "^0.3.1",
         "moment-timezone": "^0.5.13",
-        "needle": "^1.6.0",
+        "needle": "^2.0.0",
         "random-useragent": "^0.3.1",
         "relaxed-json": "^1.0.1",
         "socks-proxy-agent": "^3.0.0",
@@ -47,11 +47,11 @@
         "babel-polyfill": "^6.23.0",
         "babel-preset-es2015": "^6.24.1",
         "babel-preset-stage-0": "^6.24.1",
-        "eslint": "^4.0.0",
+        "eslint": "^4.4.1",
         "ink-docstrap": "^1.3.0",
-        "jsdoc": "^3.4.3",
-        "mocha": "^3.4.2",
+        "jsdoc": "^3.5.4",
+        "mocha": "^3.5.0",
         "trevor": "^2.3.0",
-        "tz-lookup": "^6.1.0"
+        "tz-lookup": "^6.1.1"
     }
 }


### PR DESCRIPTION
Needle has had an update to 2.0.0, start using it to keep our dependencies up-to-date.

Also includes some minor bumps for cheerio, eslint, jsdoc, mocha, and tz-lookup.