### PR TITLE
Fix Tokyo Disneyland

### DIFF
--- a/lib/disneytokyo/index.js
+++ b/lib/disneytokyo/index.js
@@ -241,13 +241,14 @@ class DisneyTokyoPark extends Park {
 
                 // request cookie for accessing wait times using a random location in the park
                 this.HTTP({
-                    url: `http://info.tokyodisneyresort.jp/s/gps/${this[s_parkID]}_index.html`,
+                    url: `https://info.tokyodisneyresort.jp/rt/s/gps/${this[s_parkID]}_index.html`,
                     data: {
                         nextUrl: `http://info.tokyodisneyresort.jp/rt/s/realtime/${this[s_parkID]}_attraction.html`,
                         lat: randomGeoLocation.LatitudeRaw,
                         lng: randomGeoLocation.LongitudeRaw
                     },
                     headers: {
+                        connection: "keep-alive",
                         "Referer": `http://www.tokyodisneyresort.jp/en/attraction/lists/park:${this[s_parkID]}`,
                     },
                     // don't actually follow the redirect, we just want the cookie
@@ -313,6 +314,7 @@ class DisneyTokyoPark extends Park {
                     forceJSON: true,
                     headers: {
                         "Referer": `http://www.tokyodisneyresort.jp/en/attraction/lists/park:${this[s_parkID]}`,
+                        connection: "keep-alive",
                     },
                 }).then(function(body) {
                     if (!body || !body.entries || !body.entries.length) {

--- a/lib/disneytokyo/index.js
+++ b/lib/disneytokyo/index.js
@@ -110,7 +110,8 @@ class DisneyTokyoPark extends Park {
             return this.HTTP({
                 url: `http://info.tokyodisneyresort.jp/rt/s/realtime/${this[s_parkID]}_attraction.html`,
                 headers: {
-                    "Cookie": `tdrloc=${encodeURIComponent(access_token)}`
+                    "Cookie": `tdrloc=${encodeURIComponent(access_token)}`,
+                    connection: "keep-alive",
                 }
             });
         });
@@ -206,7 +207,8 @@ class DisneyTokyoPark extends Park {
                 url: `http://www.tokyodisneyresort.jp/api/v1/wapi_monthlycalendars/detail/ym:${month}/`,
                 headers: {
                     "Referer": `http://www.tokyodisneyresort.jp/en/attraction/lists/park:${this[s_parkID]}`,
-                    "X-Requested-With": "XMLHttpRequest"
+                    "X-Requested-With": "XMLHttpRequest",
+                    connection: "keep-alive",
                 },
                 forceJSON: true
             }).then(function(body) {


### PR DESCRIPTION
In a very unusual change, the Tokyo Disneyland servers have started rejecting any web requests without the "Connection: Keep-Alive" header.

This may be a server change mistake, or an intentional attempt to stop projects such as this one. I am going to assume it was a mistake for now since this appears to be server-wide and not specifically for the wait times pages, but it will be worth keeping an eye on the Tokyo Disneyland wait time service in the future to be sure.