### PR TITLE
Added all types of ride states to show also downtime on Efteling

### DIFF
--- a/lib/efteling/index.js
+++ b/lib/efteling/index.js
@@ -126,9 +126,13 @@ class Efteling extends Park {
 
                         if (rideObject) {
                             // update ride with wait time data
-                            //  if the State isn't "open", assume ride is closed
-                            // TODO - learn how Efteling marks rides as under refurb and set = -2
-                            rideObject.WaitTime = item.State == "open" ? parseInt(item.WaitingTime, 10) : -1;
+                            if(item.State == "storing" || item.State == "inonderhoud"){
+                                rideObject.WaitTime = -2;
+                            }else if(item.State == "open"){
+                                rideObject.WaitTime = parseInt(item.WaitingTime, 10);
+                            }else{
+                                rideObject.WaitTime = -1;
+                            }
                         }
                     }
                 });


### PR DESCRIPTION
I work a lot with the data of this park, and this covers all. 'Storing' is 'interruption', and 'inonderhoud' is 'planned maintenance'.