### PR TITLE
Added Refurbishment as a WaitTime value

### DIFF
--- a/lib/ride.js
+++ b/lib/ride.js
@@ -285,6 +285,9 @@ class Ride {
             return todaysSchedule.type;
         }
 
+        // wait time set to -3 when ride is down for Refurbishment
+        if (this[s_currentWaitTime] == -3) return "Refurbishment";        
+        
         // wait time set to -2 when ride is Down
         if (this[s_currentWaitTime] == -2) return "Down";
 


### PR DESCRIPTION
Some parks like Efteling return when rides are closed due to Refurbishment in the api, but don't use schedules for it. To support this, and return good states of the ride, I would like to add WaitTime -3 for 'down for refurbishment'.