### PR TITLE
[5.0] Add alternative services to bus times

### DIFF
--- a/lib/disney/disneyBuses.js
+++ b/lib/disney/disneyBuses.js
@@ -82,6 +82,7 @@ class DisneyLiveBusTimes extends EventEmitter {
                 frequencyHuman: dest.frequency_human,
                 transfers: dest.transfers,
                 transfersHuman: dest.transfers_human,
+                alternativeServices: dest.services || [],
               });
             });
           } else {
@@ -96,6 +97,7 @@ class DisneyLiveBusTimes extends EventEmitter {
               frequencyHuman: dest.frequency_human,
               transfers: dest.transfers,
               transfersHuman: dest.transfers_human,
+              alternativeServices: dest.services || [],
             });
           }
         });


### PR DESCRIPTION
For resorts that offer multiple transport services (boats, monorails, etc), they're listed on bus stops. Additionally, the status is listed.

Example:
```
[
    {
        "type": "Monorail",
        "status": "Available"
    },
    {
        "type": "Watercraft",
        "status": "Available"
    }
]
```