### PR TITLE
Fixes an issue with the HTTP wrapper

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -33,7 +33,7 @@ function MakeRequest(networkRequest) {
     if (!requestURL) return Promise.reject(`No URL defined for ${requestMethod} request`);
     delete networkRequest.url;
 
-    var requestData = networkRequest.data || networkRequest.body || {};
+    var requestData = networkRequest.data || networkRequest.body || undefined;
     delete networkRequest.data;
     delete networkRequest.body;
 
@@ -55,15 +55,15 @@ function MakeRequest(networkRequest) {
     delete networkRequest.forceJSON;
 
     // return result as a Promise!
-    return new Promise(function(resolve, reject) {
+    return new Promise(function (resolve, reject) {
         var attempt = 0;
 
         // make request in an anonymouse function so we can make multiple requests to it easily
-        var attemptRequest = function() {
+        var attemptRequest = function () {
             Log(`Calling ${requestMethod}:${requestURL}`);
 
             // build Needle request
-            needle.request(requestMethod, requestURL, requestData, networkRequest, function(err, resp) {
+            needle.request(requestMethod, requestURL, requestData, networkRequest, function (err, resp) {
                 if (err || resp.statusCode >= 400 || (resp.statusCode == 200 && !resp.body)) {
                     Log(`Network request failed attempt ${attempt}/${retries} for URL ${requestURL}`);
                     Log(err || (resp.statusCode + ": " + JSON.stringify(resp.body, null, 2)));


### PR DESCRIPTION
A GET request always contained the question mark symbol even without query strings.

It can have an impact on some bad APIs (as ThorpePark / AltonTowers).
e.g. the second request contains two entries less than the first request:
* https://www.thorpepark.com/Umbraco/Api/Calendar/GetAllOpeningTimes
* https://www.thorpepark.com/Umbraco/Api/Calendar/GetAllOpeningTimes?

![2019-05-16 13_38_33-Insomnia](https://user-images.githubusercontent.com/1443167/57851097-02828a80-77e0-11e9-867f-e0398b5a1d96.png)

![2019-05-16 13_38_51-Insomnia](https://user-images.githubusercontent.com/1443167/57851098-02828a80-77e0-11e9-9862-a9da140a1c92.png)

