### PR TITLE
Fixes ShanghaiDisneyResort

### DIFF
--- a/lib/disney/shanghaidisneyresort.js
+++ b/lib/disney/shanghaidisneyresort.js
@@ -45,6 +45,12 @@ class ShanghaiDisneyResortMagicKingdom extends DisneyBase {
     get FetchScheduleTimesURL() {
         return `${this.APIBase}explorer-service/public/ancestor-activities-schedules/shdr;entityType=destination`;
     }
+
+    HTTP(options) {
+        // Allows unauthorized HTTPS certificates as ShanghaiDisneyResort uses a self-signed certificate
+        options.rejectUnauthorized = false;
+        return super.HTTP(options);
+    }
 }
 
 module.exports = ShanghaiDisneyResortMagicKingdom;


### PR DESCRIPTION
Allows unauthorized HTTPS certificates as ShanghaiDisneyResort uses a self-signed certificate