### PR TITLE
Add emitted events when ride times change

### DIFF
--- a/lib/location.js
+++ b/lib/location.js
@@ -1,6 +1,8 @@
 // time/date handling library
 const Moment = require('moment-timezone');
 
+const EventEmitter = require('events');
+
 // a basic debug log wrapper
 const DebugLog = require('./debugPrint.js');
 
@@ -31,7 +33,7 @@ function formatNumberToGeoLocation(number) {
  * Location class used as base for any themeparks object that has a physical location (parks, resorts, restaurants etc.)
  * @class
  */
-class Location {
+class Location extends EventEmitter {
   /**
    * Create a new Location object
    * @param {Object} options
@@ -41,6 +43,8 @@ class Location {
    * @param {Number} options.longitude Location's longitude
    */
   constructor(options = {}) {
+    super();
+
     // parse longitude and latitude values
     this[sLongitude] = parseFloat(options.longitude);
     this[sLatitude] = parseFloat(options.latitude);

--- a/lib/park.js
+++ b/lib/park.js
@@ -30,6 +30,8 @@ const sRideObjects = Symbol('Rides');
 const sMemCache = Symbol('Memory Cache');
 const sScheduleObject = Symbol('Schedule');
 const sScheduleDaysToReturn = Symbol('Schedule Size');
+const sFirstWaitTimesCacheRestore = Symbol('Has the cache been used yet? If we restore from cache, fire off initial events from cached data');
+const sPollerTimeout = Symbol('Timeout used for polling wait times');
 
 function DefaultUserAgent(ua) {
   return (ua.osName === 'Android');
@@ -91,6 +93,8 @@ class Park extends Location {
 
     // how many days to return by default?
     this[sScheduleDaysToReturn] = options.scheduleDaysToReturn || 60;
+
+    this[sFirstWaitTimesCacheRestore] = false;
   }
 
   /**
@@ -104,12 +108,44 @@ class Park extends Location {
     // return database cached data
     return this.GetCached('waittimes').then((cachedResponse) => {
       if (cachedResponse !== null) {
+        // fire our ride update events if our park has been freshly restored from the cache
+        if (!this[sFirstWaitTimesCacheRestore]) {
+          this.Log('Broadcasting initial ride updates from cached data');
+          cachedResponse.forEach((ride) => {
+            this.emit('rideStateUpdated', ride, undefined, undefined);
+          });
+          this[sFirstWaitTimesCacheRestore] = true;
+        }
+
         // return cached response if available
         return Promise.resolve(cachedResponse);
       }
+
+      this[sFirstWaitTimesCacheRestore] = true;
+
       // no cached data? call FetchWaitTimes to fetch fresh data
       return this.FetchWaitTimes().then(() => this.BuildWaitTimesResponse().then(response => this.SetCached('waittimes', response).then(() => Promise.resolve(response))));
     });
+  }
+
+  /**
+   * Start polling wait times automatically
+   * This will fire the 'rideStateUpdated' event automatically when ride times change.
+   */
+  StartPolling() {
+    if (this[sPollerTimeout] === undefined) {
+      const Updater = () => {
+        // call GetWaitTimes to trigger ride updates
+        this.GetWaitTimes().catch((error) => {
+          this.Log('Error', error);
+          return Promise.resolve();
+        });
+      };
+
+      // call updater every minute
+      this[sPollerTimeout] = setInterval(Updater, 1000 * 60);
+      Updater(); // call Updater initially
+    }
   }
 
   /**
@@ -179,6 +215,11 @@ class Park extends Location {
       rideId: parkRideID,
       timezone: this.Timezone,
       forceCreate: true,
+    });
+
+    // subscribe to ride events and spit back out
+    this[sRideObjects][parkRideID].on('rideStateUpdated', (rideJSON, previousTime, previousState) => {
+      this.emit('rideStateUpdated', rideJSON, previousTime, previousState);
     });
 
     return this[sRideObjects][parkRideID];

--- a/lib/ride.js
+++ b/lib/ride.js
@@ -88,6 +88,7 @@ class Ride extends Location {
 
     // restore wait time
     const prevWaitTime = this[sCurrentWaitTime];
+    const prevStatus = this.Status;
     if (input.status !== undefined && input.status !== 'Operating') {
       // if status isn't "Operating", wait time must be a negative number. Restore correctly
       if (input.status === 'Refurbishment') {
@@ -105,10 +106,19 @@ class Ride extends Location {
 
     // restore last update time
     if (input.lastUpdate !== undefined) {
+      // restore lastUpdate from cache
       this[sLastTimeUpdate] = input.lastUpdate;
     } else if (waitTimeChanged) {
       // wait time changed, mark change
       this[sLastTimeUpdate] = new Date().toISOString();
+    }
+
+    // broadcast event if the wait time has been updated
+    //  this is user-facing, so return JSON object with sanitized previous waittime and previous status
+    if (waitTimeChanged) {
+      const oldWaitTimeClean = Math.max(prevWaitTime, 0);
+      // eslint-disable-next-line no-restricted-globals
+      this.emit('rideStateUpdated', this.toJSON(), isNaN(oldWaitTimeClean) ? undefined : oldWaitTimeClean, prevWaitTime === undefined ? undefined : prevStatus);
     }
   }
 


### PR DESCRIPTION
Proposed example usage:

```
const PA = new themeparks.Parks.PortAventura();
PA.on('rideStateUpdated', (ride, previousTime, previousStatus) => {
  console.log(`${ride.name} was ${previousTime}, now ${ride.waitTime} (${previousStatus} => ${ride.status})`);
});
PA.StartPolling();
```

previousTime and previousStatus return undefined if this is the first update of a process run.

This does a few things:

1. Avoids people manually setting up less-than-ideal timer loops where developers reinstantiate park objects multiple times, or call update too frequently
2. Encourages developers to not attach GetWaitTimes directly to public API calls (i.e, app HTTP calls are calling GetWaitTimes directly, which has unknown side-effects based on park state, should be returning cached results instead)
3. Allows live-response parks (WDW & DL) to return park results in real-time, rather than waiting for poll requests by developers to give updated times

Still need to test thoroughly, as now all parks are EventEmitters, which is new.
Also need to check over live Disney parks and ensure they flush their temporary cache when live rides come through.