### PR TITLE
added heidepark

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,16 +17,17 @@ An unofficial API library for accessing ride wait times and park opening times f
 If you have been using themeparks 4.x, please follow this guide to [migrate from themeparks 4.x to themeparks 5.x](https://github.com/cubehouse/themeparks/wiki/Migrating-from-4.x-to-5.x)
 
 ## Settings
+
 You can change some settings of the library by editing the properties of the `Themeparks.Settings` object.
 
-|Property|Default value|Description|
-|:-------|:------------|:----------|
-|Cache|`${process.cwd()}/themeparks.db`|Location of Sqlite DB file|
-|OpenTimeout|10 seconds|Open request timeout value (in milliseconds)|
-|ReadTimeout|0 seconds|Read request timeout value (in milliseconds)|
-|DefaultCacheLength|6 hours|Time to cache any data (in seconds)|
-|CacheWaitTimesLength|5 minutes|Time to cache waiting times (in seconds)|
-|CacheOpeningTimesLength|1 hour|Time to cache opening times (in seconds)|
+| Property                | Default value                    | Description                                  |
+| :---------------------- | :------------------------------- | :------------------------------------------- |
+| Cache                   | `${process.cwd()}/themeparks.db` | Location of Sqlite DB file                   |
+| OpenTimeout             | 10 seconds                       | Open request timeout value (in milliseconds) |
+| ReadTimeout             | 0 seconds                        | Read request timeout value (in milliseconds) |
+| DefaultCacheLength      | 6 hours                          | Time to cache any data (in seconds)          |
+| CacheWaitTimesLength    | 5 minutes                        | Time to cache waiting times (in seconds)     |
+| CacheOpeningTimesLength | 1 hour                           | Time to cache opening times (in seconds)     |
 
 ## Example Use
 
@@ -86,128 +87,131 @@ If you wish to use themeparks with a proxy, you can pass a proxy agent when you 
 
 **57** Parks Supported
 
-* Magic Kingdom - Walt Disney World Florida (ThemeParks.Parks.WaltDisneyWorldMagicKingdom)
-* Epcot - Walt Disney World Florida (ThemeParks.Parks.WaltDisneyWorldEpcot)
-* Hollywood Studios - Walt Disney World Florida (ThemeParks.Parks.WaltDisneyWorldHollywoodStudios)
-* Animal Kingdom - Walt Disney World Florida (ThemeParks.Parks.WaltDisneyWorldAnimalKingdom)
-* Magic Kingdom - Disneyland Resort (ThemeParks.Parks.DisneylandResortMagicKingdom)
-* California Adventure - Disneyland Resort (ThemeParks.Parks.DisneylandResortCaliforniaAdventure)
-* Magic Kingdom - Disneyland Paris (ThemeParks.Parks.DisneylandParisMagicKingdom)
-* Walt Disney Studios - Disneyland Paris (ThemeParks.Parks.DisneylandParisWaltDisneyStudios)
-* Hong Kong Disneyland (ThemeParks.Parks.HongKongDisneyland)
-* Magic Kingdom - Shanghai Disney Resort (ThemeParks.Parks.ShanghaiDisneyResortMagicKingdom)
-* Magic Kingdom - Tokyo Disney Resort (ThemeParks.Parks.TokyoDisneyResortMagicKingdom)
-* Disney Sea - Tokyo Disney Resort (ThemeParks.Parks.TokyoDisneyResortDisneySea)
-* Europa Park (ThemeParks.Parks.EuropaPark)
-* Hershey Park (ThemeParks.Parks.HersheyPark)
-* Parc-Asterix (ThemeParks.Parks.AsterixPark)
-* California's Great America (ThemeParks.Parks.CaliforniasGreatAmerica)
-* Canada's Wonderland (ThemeParks.Parks.CanadasWonderland)
-* Carowinds (ThemeParks.Parks.Carowinds)
-* Cedar Point (ThemeParks.Parks.CedarPoint)
-* Kings Island (ThemeParks.Parks.KingsIsland)
-* Knott's Berry Farm (ThemeParks.Parks.KnottsBerryFarm)
-* Dollywood (ThemeParks.Parks.Dollywood)
-* Silver Dollar City (ThemeParks.Parks.SilverDollarCity)
-* Seaworld Orlando (ThemeParks.Parks.SeaworldOrlando)
-* Efteling (ThemeParks.Parks.Efteling)
-* Universal Studios Florida (ThemeParks.Parks.UniversalStudiosFlorida)
-* Universal's Islands Of Adventure (ThemeParks.Parks.UniversalIslandsOfAdventure)
-* Universal Volcano Bay (ThemeParks.Parks.UniversalVolcanoBay)
-* Universal Studios Hollywood (ThemeParks.Parks.UniversalStudiosHollywood)
-* Universal Studios Singapore (ThemeParks.Parks.UniversalStudiosSingapore)
-* Universal Studios Japan (ThemeParks.Parks.UniversalStudiosJapan)
-* Six Flags Over Texas (ThemeParks.Parks.SixFlagsOverTexas)
-* Six Flags Over Georgia (ThemeParks.Parks.SixFlagsOverGeorgia)
-* Six Flags St. Louis (ThemeParks.Parks.SixFlagsStLouis)
-* Six Flags Great Adventure (ThemeParks.Parks.SixFlagsGreatAdventure)
-* Six Flags Magic Mountain (ThemeParks.Parks.SixFlagsMagicMountain)
-* Six Flags Great America (ThemeParks.Parks.SixFlagsGreatAmerica)
-* Six Flags Fiesta Texas (ThemeParks.Parks.SixFlagsFiestaTexas)
-* Six Flags Hurricane Harbor, Arlington (ThemeParks.Parks.SixFlagsHurricaneHarborArlington)
-* Six Flags Hurricane Harbor, Los Angeles (ThemeParks.Parks.SixFlagsHurricaneHarborLosAngeles)
-* Six Flags America (ThemeParks.Parks.SixFlagsAmerica)
-* Six Flags Discovery Kingdom (ThemeParks.Parks.SixFlagsDiscoveryKingdom)
-* Six Flags New England (ThemeParks.Parks.SixFlagsNewEngland)
-* Six Flags Hurricane Harbor, Jackson (ThemeParks.Parks.SixFlagsHurricaneHarborJackson)
-* The Great Escape (ThemeParks.Parks.TheGreatEscape)
-* Six Flags White Water, Atlanta (ThemeParks.Parks.SixFlagsWhiteWaterAtlanta)
-* Six Flags México (ThemeParks.Parks.SixFlagsMexico)
-* La Ronde, Montreal (ThemeParks.Parks.LaRondeMontreal)
-* Six Flags Hurricane Harbor, Oaxtepec (ThemeParks.Parks.SixFlagsHurricaneHarborOaxtepec)
-* Six Flags Hurricane Harbor, Concord (ThemeParks.Parks.SixFlagsHurricaneHarborConcord)
-* PortAventura (ThemeParks.Parks.PortAventura)
-* Ferrari Land (ThemeParks.Parks.FerrariLand)
-* Alton Towers (ThemeParks.Parks.AltonTowers)
-* Thorpe Park (ThemeParks.Parks.ThorpePark)
-* Chessington World Of Adventures (ThemeParks.Parks.ChessingtonWorldOfAdventures)
-* Bellewaerde (ThemeParks.Parks.Bellewaerde)
-* Phantasialand (ThemeParks.Parks.Phantasialand)
+- Magic Kingdom - Walt Disney World Florida (ThemeParks.Parks.WaltDisneyWorldMagicKingdom)
+- Epcot - Walt Disney World Florida (ThemeParks.Parks.WaltDisneyWorldEpcot)
+- Hollywood Studios - Walt Disney World Florida (ThemeParks.Parks.WaltDisneyWorldHollywoodStudios)
+- Animal Kingdom - Walt Disney World Florida (ThemeParks.Parks.WaltDisneyWorldAnimalKingdom)
+- Magic Kingdom - Disneyland Resort (ThemeParks.Parks.DisneylandResortMagicKingdom)
+- California Adventure - Disneyland Resort (ThemeParks.Parks.DisneylandResortCaliforniaAdventure)
+- Magic Kingdom - Disneyland Paris (ThemeParks.Parks.DisneylandParisMagicKingdom)
+- Walt Disney Studios - Disneyland Paris (ThemeParks.Parks.DisneylandParisWaltDisneyStudios)
+- Hong Kong Disneyland (ThemeParks.Parks.HongKongDisneyland)
+- Magic Kingdom - Shanghai Disney Resort (ThemeParks.Parks.ShanghaiDisneyResortMagicKingdom)
+- Magic Kingdom - Tokyo Disney Resort (ThemeParks.Parks.TokyoDisneyResortMagicKingdom)
+- Disney Sea - Tokyo Disney Resort (ThemeParks.Parks.TokyoDisneyResortDisneySea)
+- Europa Park (ThemeParks.Parks.EuropaPark)
+- Hershey Park (ThemeParks.Parks.HersheyPark)
+- Parc-Asterix (ThemeParks.Parks.AsterixPark)
+- California's Great America (ThemeParks.Parks.CaliforniasGreatAmerica)
+- Canada's Wonderland (ThemeParks.Parks.CanadasWonderland)
+- Carowinds (ThemeParks.Parks.Carowinds)
+- Cedar Point (ThemeParks.Parks.CedarPoint)
+- Kings Island (ThemeParks.Parks.KingsIsland)
+- Knott's Berry Farm (ThemeParks.Parks.KnottsBerryFarm)
+- Dollywood (ThemeParks.Parks.Dollywood)
+- Silver Dollar City (ThemeParks.Parks.SilverDollarCity)
+- Seaworld Orlando (ThemeParks.Parks.SeaworldOrlando)
+- Efteling (ThemeParks.Parks.Efteling)
+- Universal Studios Florida (ThemeParks.Parks.UniversalStudiosFlorida)
+- Universal's Islands Of Adventure (ThemeParks.Parks.UniversalIslandsOfAdventure)
+- Universal Volcano Bay (ThemeParks.Parks.UniversalVolcanoBay)
+- Universal Studios Hollywood (ThemeParks.Parks.UniversalStudiosHollywood)
+- Universal Studios Singapore (ThemeParks.Parks.UniversalStudiosSingapore)
+- Universal Studios Japan (ThemeParks.Parks.UniversalStudiosJapan)
+- Six Flags Over Texas (ThemeParks.Parks.SixFlagsOverTexas)
+- Six Flags Over Georgia (ThemeParks.Parks.SixFlagsOverGeorgia)
+- Six Flags St. Louis (ThemeParks.Parks.SixFlagsStLouis)
+- Six Flags Great Adventure (ThemeParks.Parks.SixFlagsGreatAdventure)
+- Six Flags Magic Mountain (ThemeParks.Parks.SixFlagsMagicMountain)
+- Six Flags Great America (ThemeParks.Parks.SixFlagsGreatAmerica)
+- Six Flags Fiesta Texas (ThemeParks.Parks.SixFlagsFiestaTexas)
+- Six Flags Hurricane Harbor, Arlington (ThemeParks.Parks.SixFlagsHurricaneHarborArlington)
+- Six Flags Hurricane Harbor, Los Angeles (ThemeParks.Parks.SixFlagsHurricaneHarborLosAngeles)
+- Six Flags America (ThemeParks.Parks.SixFlagsAmerica)
+- Six Flags Discovery Kingdom (ThemeParks.Parks.SixFlagsDiscoveryKingdom)
+- Six Flags New England (ThemeParks.Parks.SixFlagsNewEngland)
+- Six Flags Hurricane Harbor, Jackson (ThemeParks.Parks.SixFlagsHurricaneHarborJackson)
+- The Great Escape (ThemeParks.Parks.TheGreatEscape)
+- Six Flags White Water, Atlanta (ThemeParks.Parks.SixFlagsWhiteWaterAtlanta)
+- Six Flags México (ThemeParks.Parks.SixFlagsMexico)
+- La Ronde, Montreal (ThemeParks.Parks.LaRondeMontreal)
+- Six Flags Hurricane Harbor, Oaxtepec (ThemeParks.Parks.SixFlagsHurricaneHarborOaxtepec)
+- Six Flags Hurricane Harbor, Concord (ThemeParks.Parks.SixFlagsHurricaneHarborConcord)
+- PortAventura (ThemeParks.Parks.PortAventura)
+- Ferrari Land (ThemeParks.Parks.FerrariLand)
+- Alton Towers (ThemeParks.Parks.AltonTowers)
+- Thorpe Park (ThemeParks.Parks.ThorpePark)
+- Chessington World Of Adventures (ThemeParks.Parks.ChessingtonWorldOfAdventures)
+- Bellewaerde (ThemeParks.Parks.Bellewaerde)
+- Phantasialand (ThemeParks.Parks.Phantasialand)
+- Heidepark (ThemeParks.Parks.HeidePark)
 
 <!-- END_SUPPORTED_PARKS_LIST -->
 
 ## Supported Park Features
 
 <!-- START_PARK_FEATURES_SUPPORTED -->
-|Park|Wait Times|Park Opening Times|Ride Opening Times|
-|:---|:---------|:-----------------|:-----------------|
-|Magic Kingdom - Walt Disney World Florida|&#10003;|&#10003;|&#10007;|
-|Epcot - Walt Disney World Florida|&#10003;|&#10003;|&#10007;|
-|Hollywood Studios - Walt Disney World Florida|&#10003;|&#10003;|&#10007;|
-|Animal Kingdom - Walt Disney World Florida|&#10003;|&#10003;|&#10007;|
-|Magic Kingdom - Disneyland Resort|&#10003;|&#10003;|&#10007;|
-|California Adventure - Disneyland Resort|&#10003;|&#10003;|&#10007;|
-|Magic Kingdom - Disneyland Paris|&#10003;|&#10003;|&#10007;|
-|Walt Disney Studios - Disneyland Paris|&#10003;|&#10003;|&#10007;|
-|Hong Kong Disneyland|&#10003;|&#10003;|&#10007;|
-|Magic Kingdom - Shanghai Disney Resort|&#10003;|&#10003;|&#10007;|
-|Magic Kingdom - Tokyo Disney Resort|&#10003;|&#10003;|&#10007;|
-|Disney Sea - Tokyo Disney Resort|&#10003;|&#10003;|&#10007;|
-|Europa Park|&#10003;|&#10003;|&#10007;|
-|Hershey Park|&#10003;|&#10003;|&#10007;|
-|Parc-Asterix|&#10003;|&#10003;|&#10003;|
-|California's Great America|&#10003;|&#10003;|&#10007;|
-|Canada's Wonderland|&#10003;|&#10003;|&#10007;|
-|Carowinds|&#10003;|&#10003;|&#10007;|
-|Cedar Point|&#10003;|&#10003;|&#10007;|
-|Kings Island|&#10003;|&#10003;|&#10007;|
-|Knott's Berry Farm|&#10003;|&#10003;|&#10007;|
-|Dollywood|&#10003;|&#10003;|&#10007;|
-|Silver Dollar City|&#10003;|&#10003;|&#10007;|
-|Seaworld Orlando|&#10003;|&#10003;|&#10007;|
-|Efteling|&#10003;|&#10003;|&#10007;|
-|Universal Studios Florida|&#10003;|&#10003;|&#10007;|
-|Universal's Islands Of Adventure|&#10003;|&#10003;|&#10007;|
-|Universal Volcano Bay|&#10003;|&#10003;|&#10007;|
-|Universal Studios Hollywood|&#10003;|&#10003;|&#10007;|
-|Universal Studios Singapore|&#10003;|&#10003;|&#10007;|
-|Universal Studios Japan|&#10003;|&#10003;|&#10007;|
-|Six Flags Over Texas|&#10003;|&#10003;|&#10007;|
-|Six Flags Over Georgia|&#10003;|&#10003;|&#10007;|
-|Six Flags St. Louis|&#10003;|&#10003;|&#10007;|
-|Six Flags Great Adventure|&#10003;|&#10003;|&#10007;|
-|Six Flags Magic Mountain|&#10003;|&#10003;|&#10007;|
-|Six Flags Great America|&#10003;|&#10003;|&#10007;|
-|Six Flags Fiesta Texas|&#10003;|&#10003;|&#10007;|
-|Six Flags Hurricane Harbor, Arlington|&#10003;|&#10003;|&#10007;|
-|Six Flags Hurricane Harbor, Los Angeles|&#10003;|&#10003;|&#10007;|
-|Six Flags America|&#10003;|&#10003;|&#10007;|
-|Six Flags Discovery Kingdom|&#10003;|&#10003;|&#10007;|
-|Six Flags New England|&#10003;|&#10003;|&#10007;|
-|Six Flags Hurricane Harbor, Jackson|&#10003;|&#10003;|&#10007;|
-|The Great Escape|&#10003;|&#10003;|&#10007;|
-|Six Flags White Water, Atlanta|&#10003;|&#10003;|&#10007;|
-|Six Flags México|&#10003;|&#10003;|&#10007;|
-|La Ronde, Montreal|&#10003;|&#10003;|&#10007;|
-|Six Flags Hurricane Harbor, Oaxtepec|&#10003;|&#10003;|&#10007;|
-|Six Flags Hurricane Harbor, Concord|&#10003;|&#10003;|&#10007;|
-|PortAventura|&#10003;|&#10003;|&#10007;|
-|Ferrari Land|&#10003;|&#10003;|&#10007;|
-|Alton Towers|&#10003;|&#10003;|&#10007;|
-|Thorpe Park|&#10003;|&#10003;|&#10007;|
-|Chessington World Of Adventures|&#10003;|&#10003;|&#10007;|
-|Bellewaerde|&#10003;|&#10003;|&#10007;|
-|Phantasialand|&#10003;|&#10003;|&#10007;|
+
+| Park                                          | Wait Times | Park Opening Times | Ride Opening Times |
+| :-------------------------------------------- | :--------- | :----------------- | :----------------- |
+| Magic Kingdom - Walt Disney World Florida     | &#10003;   | &#10003;           | &#10007;           |
+| Epcot - Walt Disney World Florida             | &#10003;   | &#10003;           | &#10007;           |
+| Hollywood Studios - Walt Disney World Florida | &#10003;   | &#10003;           | &#10007;           |
+| Animal Kingdom - Walt Disney World Florida    | &#10003;   | &#10003;           | &#10007;           |
+| Magic Kingdom - Disneyland Resort             | &#10003;   | &#10003;           | &#10007;           |
+| California Adventure - Disneyland Resort      | &#10003;   | &#10003;           | &#10007;           |
+| Magic Kingdom - Disneyland Paris              | &#10003;   | &#10003;           | &#10007;           |
+| Walt Disney Studios - Disneyland Paris        | &#10003;   | &#10003;           | &#10007;           |
+| Hong Kong Disneyland                          | &#10003;   | &#10003;           | &#10007;           |
+| Magic Kingdom - Shanghai Disney Resort        | &#10003;   | &#10003;           | &#10007;           |
+| Magic Kingdom - Tokyo Disney Resort           | &#10003;   | &#10003;           | &#10007;           |
+| Disney Sea - Tokyo Disney Resort              | &#10003;   | &#10003;           | &#10007;           |
+| Europa Park                                   | &#10003;   | &#10003;           | &#10007;           |
+| Hershey Park                                  | &#10003;   | &#10003;           | &#10007;           |
+| Parc-Asterix                                  | &#10003;   | &#10003;           | &#10003;           |
+| California's Great America                    | &#10003;   | &#10003;           | &#10007;           |
+| Canada's Wonderland                           | &#10003;   | &#10003;           | &#10007;           |
+| Carowinds                                     | &#10003;   | &#10003;           | &#10007;           |
+| Cedar Point                                   | &#10003;   | &#10003;           | &#10007;           |
+| Kings Island                                  | &#10003;   | &#10003;           | &#10007;           |
+| Knott's Berry Farm                            | &#10003;   | &#10003;           | &#10007;           |
+| Dollywood                                     | &#10003;   | &#10003;           | &#10007;           |
+| Silver Dollar City                            | &#10003;   | &#10003;           | &#10007;           |
+| Seaworld Orlando                              | &#10003;   | &#10003;           | &#10007;           |
+| Efteling                                      | &#10003;   | &#10003;           | &#10007;           |
+| Universal Studios Florida                     | &#10003;   | &#10003;           | &#10007;           |
+| Universal's Islands Of Adventure              | &#10003;   | &#10003;           | &#10007;           |
+| Universal Volcano Bay                         | &#10003;   | &#10003;           | &#10007;           |
+| Universal Studios Hollywood                   | &#10003;   | &#10003;           | &#10007;           |
+| Universal Studios Singapore                   | &#10003;   | &#10003;           | &#10007;           |
+| Universal Studios Japan                       | &#10003;   | &#10003;           | &#10007;           |
+| Six Flags Over Texas                          | &#10003;   | &#10003;           | &#10007;           |
+| Six Flags Over Georgia                        | &#10003;   | &#10003;           | &#10007;           |
+| Six Flags St. Louis                           | &#10003;   | &#10003;           | &#10007;           |
+| Six Flags Great Adventure                     | &#10003;   | &#10003;           | &#10007;           |
+| Six Flags Magic Mountain                      | &#10003;   | &#10003;           | &#10007;           |
+| Six Flags Great America                       | &#10003;   | &#10003;           | &#10007;           |
+| Six Flags Fiesta Texas                        | &#10003;   | &#10003;           | &#10007;           |
+| Six Flags Hurricane Harbor, Arlington         | &#10003;   | &#10003;           | &#10007;           |
+| Six Flags Hurricane Harbor, Los Angeles       | &#10003;   | &#10003;           | &#10007;           |
+| Six Flags America                             | &#10003;   | &#10003;           | &#10007;           |
+| Six Flags Discovery Kingdom                   | &#10003;   | &#10003;           | &#10007;           |
+| Six Flags New England                         | &#10003;   | &#10003;           | &#10007;           |
+| Six Flags Hurricane Harbor, Jackson           | &#10003;   | &#10003;           | &#10007;           |
+| The Great Escape                              | &#10003;   | &#10003;           | &#10007;           |
+| Six Flags White Water, Atlanta                | &#10003;   | &#10003;           | &#10007;           |
+| Six Flags México                              | &#10003;   | &#10003;           | &#10007;           |
+| La Ronde, Montreal                            | &#10003;   | &#10003;           | &#10007;           |
+| Six Flags Hurricane Harbor, Oaxtepec          | &#10003;   | &#10003;           | &#10007;           |
+| Six Flags Hurricane Harbor, Concord           | &#10003;   | &#10003;           | &#10007;           |
+| PortAventura                                  | &#10003;   | &#10003;           | &#10007;           |
+| Ferrari Land                                  | &#10003;   | &#10003;           | &#10007;           |
+| Alton Towers                                  | &#10003;   | &#10003;           | &#10007;           |
+| Thorpe Park                                   | &#10003;   | &#10003;           | &#10007;           |
+| Chessington World Of Adventures               | &#10003;   | &#10003;           | &#10007;           |
+| Bellewaerde                                   | &#10003;   | &#10003;           | &#10007;           |
+| Phantasialand                                 | &#10003;   | &#10003;           | &#10007;           |
+| HeidePark                                     | &#10003;   | &#10003;           | &#10007;           |
 
 <!-- END_PARK_FEATURES_SUPPORTED -->
 
@@ -268,18 +272,18 @@ If you wish to use themeparks with a proxy, you can pass a proxy agent when you 
 
 There are some values available on each park object that may be useful.
 
-|Variable|Description|
-|:-------|:----------|
-|Name|Name of the park|
-|Timezone|The park's local timezone|
-|LocationString|This park's location as a geolocation string|
-|SupportsWaitTimes|Does this park's API support ride wait times?|
-|SupportsOpeningTimes|Does this park's API support opening hours?|
-|SupportsRideSchedules|Does this park return schedules for rides?|
-|FastPass|Does this park have FastPass (or a FastPass-style service)?|
-|FastPassReturnTimes|Does this park tell you the FastPass return times?|
-|Now|Current date/time at this park (returned as a Moment object)|
-|UserAgent|The HTTP UserAgent this park is using to make API requests (usually randomly generated per-park at runtime)|
+| Variable              | Description                                                                                                 |
+| :-------------------- | :---------------------------------------------------------------------------------------------------------- |
+| Name                  | Name of the park                                                                                            |
+| Timezone              | The park's local timezone                                                                                   |
+| LocationString        | This park's location as a geolocation string                                                                |
+| SupportsWaitTimes     | Does this park's API support ride wait times?                                                               |
+| SupportsOpeningTimes  | Does this park's API support opening hours?                                                                 |
+| SupportsRideSchedules | Does this park return schedules for rides?                                                                  |
+| FastPass              | Does this park have FastPass (or a FastPass-style service)?                                                 |
+| FastPassReturnTimes   | Does this park tell you the FastPass return times?                                                          |
+| Now                   | Current date/time at this park (returned as a Moment object)                                                |
+| UserAgent             | The HTTP UserAgent this park is using to make API requests (usually randomly generated per-park at runtime) |
 
     const ThemeParks = require("themeparks");
 
@@ -298,63 +302,64 @@ Prints:
 
 <!-- START_PARK_TIMEZONE_LIST -->
 
-* Magic Kingdom - Walt Disney World Florida [(28°23′6.72″N, 81°33′50.04″W)]: (America/New_York)
-* Epcot - Walt Disney World Florida [(28°22′28.92″N, 81°32′57.84″W)]: (America/New_York)
-* Hollywood Studios - Walt Disney World Florida [(28°21′27.00″N, 81°33′29.52″W)]: (America/New_York)
-* Animal Kingdom - Walt Disney World Florida [(28°21′19.08″N, 81°35′24.36″W)]: (America/New_York)
-* Magic Kingdom - Disneyland Resort [(33°48′36.39″N, 117°55′8.30″W)]: (America/Los_Angeles)
-* California Adventure - Disneyland Resort [(33°48′31.39″N, 117°55′8.36″W)]: (America/Los_Angeles)
-* Magic Kingdom - Disneyland Paris [(48°52′13.16″N, 2°46′46.82″E)]: (Europe/Paris)
-* Walt Disney Studios - Disneyland Paris [(48°52′5.78″N, 2°46′50.59″E)]: (Europe/Paris)
-* Hong Kong Disneyland [(22°18′47.52″N, 114°2′40.20″E)]: (Asia/Hong_Kong)
-* Magic Kingdom - Shanghai Disney Resort [(31°8′35.88″N, 121°39′28.80″E)]: (Asia/Shanghai)
-* Magic Kingdom - Tokyo Disney Resort [(35°38′5.45″N, 139°52′45.46″E)]: (Asia/Tokyo)
-* Disney Sea - Tokyo Disney Resort [(35°37′37.40″N, 139°53′20.75″E)]: (Asia/Tokyo)
-* Europa Park [(48°16′8.15″N, 7°43′17.61″E)]: (Europe/Berlin)
-* Hershey Park [(40°17′15.65″N, 76°39′30.88″W)]: (America/New_York)
-* Parc-Asterix [(49°8′9.75″N, 2°34′21.96″E)]: (Europe/Paris)
-* California's Great America [(37°23′52.08″N, 121°58′28.98″W)]: (America/Los_Angeles)
-* Canada's Wonderland [(43°50′34.80″N, 79°32′20.40″W)]: (America/Toronto)
-* Carowinds [(35°6′16.20″N, 80°56′21.84″W)]: (America/New_York)
-* Cedar Point [(41°28′42.24″N, 82°40′45.48″W)]: (America/New_York)
-* Kings Island [(39°20′40.92″N, 84°16′6.96″W)]: (America/New_York)
-* Knott's Berry Farm [(33°50′39.12″N, 117°59′54.96″W)]: (America/Los_Angeles)
-* Dollywood [(35°47′43.18″N, 83°31′51.19″W)]: (America/New_York)
-* Silver Dollar City [(36°40′5.44″N, 93°20′18.84″W)]: (America/Chicago)
-* Seaworld Orlando [(28°24′41.40″N, 81°27′48.24″W)]: (America/New_York)
-* Efteling [(51°38′59.67″N, 5°2′36.82″E)]: (Europe/Amsterdam)
-* Universal Studios Florida [(28°28′29.94″N, 81°27′59.39″W)]: (America/New_York)
-* Universal's Islands Of Adventure [(28°28′20.07″N, 81°28′4.28″W)]: (America/New_York)
-* Universal Volcano Bay [(28°27′44.28″N, 81°28′14.52″W)]: (America/New_York)
-* Universal Studios Hollywood [(34°8′14.14″N, 118°21′19.86″W)]: (America/Los_Angeles)
-* Universal Studios Singapore [(1°15′15.30″N, 103°49′25.67″E)]: (Asia/Singapore)
-* Universal Studios Japan [(34°39′55.74″N, 135°25′56.50″E)]: (Asia/Tokyo)
-* Six Flags Over Texas [(32°45′17.95″N, 97°4′13.33″W)]: (America/Chicago)
-* Six Flags Over Georgia [(33°46′14.08″N, 84°33′5.36″W)]: (America/New_York)
-* Six Flags St. Louis [(38°30′47.61″N, 90°40′30.69″W)]: (America/Chicago)
-* Six Flags Great Adventure [(40°8′55.18″N, 74°26′27.69″W)]: (America/New_York)
-* Six Flags Magic Mountain [(34°25′24.46″N, 118°35′42.90″W)]: (America/Los_Angeles)
-* Six Flags Great America [(42°22′12.88″N, 87°56′9.30″W)]: (America/Chicago)
-* Six Flags Fiesta Texas [(29°35′59.28″N, 98°36′32.50″W)]: (America/Chicago)
-* Six Flags Hurricane Harbor, Arlington [(32°45′43.20″N, 97°4′58.44″W)]: (America/Chicago)
-* Six Flags Hurricane Harbor, Los Angeles [(34°25′25.86″N, 118°35′42.05″W)]: (America/Los_Angeles)
-* Six Flags America [(38°54′4.46″N, 76°46′16.59″W)]: (America/New_York)
-* Six Flags Discovery Kingdom [(38°8′19.43″N, 122°13′59.70″W)]: (America/Los_Angeles)
-* Six Flags New England [(42°2′16.54″N, 72°36′55.92″W)]: (America/New_York)
-* Six Flags Hurricane Harbor, Jackson [(40°8′18.24″N, 74°26′25.80″W)]: (America/New_York)
-* The Great Escape [(43°21′1.80″N, 73°41′32.10″W)]: (America/New_York)
-* Six Flags White Water, Atlanta [(33°57′32.86″N, 84°31′10.37″W)]: (America/New_York)
-* Six Flags México [(19°17′43.40″N, 99°12′41.19″W)]: (America/Mexico_City)
-* La Ronde, Montreal [(45°31′19.18″N, 73°32′4.48″W)]: (America/Toronto)
-* Six Flags Hurricane Harbor, Oaxtepec [(18°53′48.12″N, 98°58′31.44″W)]: (America/Mexico_City)
-* Six Flags Hurricane Harbor, Concord [(37°58′23.89″N, 122°3′1.98″W)]: (America/Los_Angeles)
-* PortAventura [(41°5′11.24″N, 1°9′13.14″E)]: (Europe/Madrid)
-* Ferrari Land [(41°5′10.08″N, 1°9′11.67″E)]: (Europe/Madrid)
-* Alton Towers [(52°59′27.83″N, 1°53′32.25″W)]: (Europe/London)
-* Thorpe Park [(51°24′19.80″N, 0°30′37.80″W)]: (Europe/London)
-* Chessington World Of Adventures [(51°20′58.56″N, 0°18′52.45″W)]: (Europe/London)
-* Bellewaerde [(50°50′49.19″N, 2°56′52.61″E)]: (Europe/Brussels)
-* Phantasialand [(50°47′56.23″N, 6°52′45.53″E)]: (Europe/Berlin)
+- Magic Kingdom - Walt Disney World Florida [(28°23′6.72″N, 81°33′50.04″W)]: (America/New_York)
+- Epcot - Walt Disney World Florida [(28°22′28.92″N, 81°32′57.84″W)]: (America/New_York)
+- Hollywood Studios - Walt Disney World Florida [(28°21′27.00″N, 81°33′29.52″W)]: (America/New_York)
+- Animal Kingdom - Walt Disney World Florida [(28°21′19.08″N, 81°35′24.36″W)]: (America/New_York)
+- Magic Kingdom - Disneyland Resort [(33°48′36.39″N, 117°55′8.30″W)]: (America/Los_Angeles)
+- California Adventure - Disneyland Resort [(33°48′31.39″N, 117°55′8.36″W)]: (America/Los_Angeles)
+- Magic Kingdom - Disneyland Paris [(48°52′13.16″N, 2°46′46.82″E)]: (Europe/Paris)
+- Walt Disney Studios - Disneyland Paris [(48°52′5.78″N, 2°46′50.59″E)]: (Europe/Paris)
+- Hong Kong Disneyland [(22°18′47.52″N, 114°2′40.20″E)]: (Asia/Hong_Kong)
+- Magic Kingdom - Shanghai Disney Resort [(31°8′35.88″N, 121°39′28.80″E)]: (Asia/Shanghai)
+- Magic Kingdom - Tokyo Disney Resort [(35°38′5.45″N, 139°52′45.46″E)]: (Asia/Tokyo)
+- Disney Sea - Tokyo Disney Resort [(35°37′37.40″N, 139°53′20.75″E)]: (Asia/Tokyo)
+- Europa Park [(48°16′8.15″N, 7°43′17.61″E)]: (Europe/Berlin)
+- Hershey Park [(40°17′15.65″N, 76°39′30.88″W)]: (America/New_York)
+- Parc-Asterix [(49°8′9.75″N, 2°34′21.96″E)]: (Europe/Paris)
+- California's Great America [(37°23′52.08″N, 121°58′28.98″W)]: (America/Los_Angeles)
+- Canada's Wonderland [(43°50′34.80″N, 79°32′20.40″W)]: (America/Toronto)
+- Carowinds [(35°6′16.20″N, 80°56′21.84″W)]: (America/New_York)
+- Cedar Point [(41°28′42.24″N, 82°40′45.48″W)]: (America/New_York)
+- Kings Island [(39°20′40.92″N, 84°16′6.96″W)]: (America/New_York)
+- Knott's Berry Farm [(33°50′39.12″N, 117°59′54.96″W)]: (America/Los_Angeles)
+- Dollywood [(35°47′43.18″N, 83°31′51.19″W)]: (America/New_York)
+- Silver Dollar City [(36°40′5.44″N, 93°20′18.84″W)]: (America/Chicago)
+- Seaworld Orlando [(28°24′41.40″N, 81°27′48.24″W)]: (America/New_York)
+- Efteling [(51°38′59.67″N, 5°2′36.82″E)]: (Europe/Amsterdam)
+- Universal Studios Florida [(28°28′29.94″N, 81°27′59.39″W)]: (America/New_York)
+- Universal's Islands Of Adventure [(28°28′20.07″N, 81°28′4.28″W)]: (America/New_York)
+- Universal Volcano Bay [(28°27′44.28″N, 81°28′14.52″W)]: (America/New_York)
+- Universal Studios Hollywood [(34°8′14.14″N, 118°21′19.86″W)]: (America/Los_Angeles)
+- Universal Studios Singapore [(1°15′15.30″N, 103°49′25.67″E)]: (Asia/Singapore)
+- Universal Studios Japan [(34°39′55.74″N, 135°25′56.50″E)]: (Asia/Tokyo)
+- Six Flags Over Texas [(32°45′17.95″N, 97°4′13.33″W)]: (America/Chicago)
+- Six Flags Over Georgia [(33°46′14.08″N, 84°33′5.36″W)]: (America/New_York)
+- Six Flags St. Louis [(38°30′47.61″N, 90°40′30.69″W)]: (America/Chicago)
+- Six Flags Great Adventure [(40°8′55.18″N, 74°26′27.69″W)]: (America/New_York)
+- Six Flags Magic Mountain [(34°25′24.46″N, 118°35′42.90″W)]: (America/Los_Angeles)
+- Six Flags Great America [(42°22′12.88″N, 87°56′9.30″W)]: (America/Chicago)
+- Six Flags Fiesta Texas [(29°35′59.28″N, 98°36′32.50″W)]: (America/Chicago)
+- Six Flags Hurricane Harbor, Arlington [(32°45′43.20″N, 97°4′58.44″W)]: (America/Chicago)
+- Six Flags Hurricane Harbor, Los Angeles [(34°25′25.86″N, 118°35′42.05″W)]: (America/Los_Angeles)
+- Six Flags America [(38°54′4.46″N, 76°46′16.59″W)]: (America/New_York)
+- Six Flags Discovery Kingdom [(38°8′19.43″N, 122°13′59.70″W)]: (America/Los_Angeles)
+- Six Flags New England [(42°2′16.54″N, 72°36′55.92″W)]: (America/New_York)
+- Six Flags Hurricane Harbor, Jackson [(40°8′18.24″N, 74°26′25.80″W)]: (America/New_York)
+- The Great Escape [(43°21′1.80″N, 73°41′32.10″W)]: (America/New_York)
+- Six Flags White Water, Atlanta [(33°57′32.86″N, 84°31′10.37″W)]: (America/New_York)
+- Six Flags México [(19°17′43.40″N, 99°12′41.19″W)]: (America/Mexico_City)
+- La Ronde, Montreal [(45°31′19.18″N, 73°32′4.48″W)]: (America/Toronto)
+- Six Flags Hurricane Harbor, Oaxtepec [(18°53′48.12″N, 98°58′31.44″W)]: (America/Mexico_City)
+- Six Flags Hurricane Harbor, Concord [(37°58′23.89″N, 122°3′1.98″W)]: (America/Los_Angeles)
+- PortAventura [(41°5′11.24″N, 1°9′13.14″E)]: (Europe/Madrid)
+- Ferrari Land [(41°5′10.08″N, 1°9′11.67″E)]: (Europe/Madrid)
+- Alton Towers [(52°59′27.83″N, 1°53′32.25″W)]: (Europe/London)
+- Thorpe Park [(51°24′19.80″N, 0°30′37.80″W)]: (Europe/London)
+- Chessington World Of Adventures [(51°20′58.56″N, 0°18′52.45″W)]: (Europe/London)
+- Bellewaerde [(50°50′49.19″N, 2°56′52.61″E)]: (Europe/Brussels)
+- Phantasialand [(50°47′56.23″N, 6°52′45.53″E)]: (Europe/Berlin)
+- HeidePark [(53°01′28.7″N, 9°52′25.7″E)]: (Europe/Berlin)
 
 <!-- END_PARK_TIMEZONE_LIST -->
 
@@ -368,7 +373,7 @@ Run the following to test the library's unit tests (this will build the library 
 
     npm test
 
-You can also run unit tests against the source js files using ```npm run testdev```.
+You can also run unit tests against the source js files using `npm run testdev`.
 
 There is a separate test for checking the library still connects to park APIs correctly. This is the "online test".
 
@@ -410,11 +415,11 @@ If you're using themeparks for a project, please let me know! I'd love to see wh
 
 ### Websites and Mobile Apps
 
-* [My Disney Visit](http://www.mydisneyvisit.com/) - Walt Disney World
-* [ChronoPass](https://www.chronopass.app) - All parks
+- [My Disney Visit](http://www.mydisneyvisit.com/) - Walt Disney World
+- [ChronoPass](https://www.chronopass.app) - All parks
 
 ### Pebble Apps
 
-* [Disneyland California Wait Times](https://apps.getpebble.com/en_US/application/5656424b4431a2ce6c00008d)
-* [Disneyland Paris Wait Times](https://apps.getpebble.com/en_US/application/55e25e8d3ea1fb6fa30000bd)
-* [Disney World Wait Times](https://apps.getpebble.com/en_US/application/54bdb77b54845b1bf40000bb)
+- [Disneyland California Wait Times](https://apps.getpebble.com/en_US/application/5656424b4431a2ce6c00008d)
+- [Disneyland Paris Wait Times](https://apps.getpebble.com/en_US/application/55e25e8d3ea1fb6fa30000bd)
+- [Disney World Wait Times](https://apps.getpebble.com/en_US/application/54bdb77b54845b1bf40000bb)

--- a/README.md
+++ b/README.md
@@ -58,22 +58,6 @@ You can change some settings of the library by editing the properties of the `Th
 
     // you can also call GetOpeningTimes on themeparks objects to get park opening hours
 
-### Using Promises or callbacks
-
-Both GetWaitTimes and GetOpeningTimes work either through callback or Promises.
-
-This is the same as the above example, but using a callback instead of a Promise.
-
-    // access wait times via callback
-    disneyMagicKingdom.GetWaitTimes((err, rides) => {
-        if (err) return console.error(err);
-
-        // print each wait time
-        for(var i=0, ride; ride=rides[i++];) {
-            console.log(`${ride.name}: ${ride.waitTime} minutes wait (${ride.status})`);
-        }
-    });
-
 ### Proxy
 
 If you wish to use themeparks with a proxy, you can pass a proxy agent when you construct the park object.

--- a/README.md
+++ b/README.md
@@ -85,133 +85,132 @@ If you wish to use themeparks with a proxy, you can pass a proxy agent when you 
 
 <!-- START_SUPPORTED_PARKS_LIST -->
 
-**57** Parks Supported
+**58** Parks Supported
 
-- Magic Kingdom - Walt Disney World Florida (ThemeParks.Parks.WaltDisneyWorldMagicKingdom)
-- Epcot - Walt Disney World Florida (ThemeParks.Parks.WaltDisneyWorldEpcot)
-- Hollywood Studios - Walt Disney World Florida (ThemeParks.Parks.WaltDisneyWorldHollywoodStudios)
-- Animal Kingdom - Walt Disney World Florida (ThemeParks.Parks.WaltDisneyWorldAnimalKingdom)
-- Magic Kingdom - Disneyland Resort (ThemeParks.Parks.DisneylandResortMagicKingdom)
-- California Adventure - Disneyland Resort (ThemeParks.Parks.DisneylandResortCaliforniaAdventure)
-- Magic Kingdom - Disneyland Paris (ThemeParks.Parks.DisneylandParisMagicKingdom)
-- Walt Disney Studios - Disneyland Paris (ThemeParks.Parks.DisneylandParisWaltDisneyStudios)
-- Hong Kong Disneyland (ThemeParks.Parks.HongKongDisneyland)
-- Magic Kingdom - Shanghai Disney Resort (ThemeParks.Parks.ShanghaiDisneyResortMagicKingdom)
-- Magic Kingdom - Tokyo Disney Resort (ThemeParks.Parks.TokyoDisneyResortMagicKingdom)
-- Disney Sea - Tokyo Disney Resort (ThemeParks.Parks.TokyoDisneyResortDisneySea)
-- Europa Park (ThemeParks.Parks.EuropaPark)
-- Hershey Park (ThemeParks.Parks.HersheyPark)
-- Parc-Asterix (ThemeParks.Parks.AsterixPark)
-- California's Great America (ThemeParks.Parks.CaliforniasGreatAmerica)
-- Canada's Wonderland (ThemeParks.Parks.CanadasWonderland)
-- Carowinds (ThemeParks.Parks.Carowinds)
-- Cedar Point (ThemeParks.Parks.CedarPoint)
-- Kings Island (ThemeParks.Parks.KingsIsland)
-- Knott's Berry Farm (ThemeParks.Parks.KnottsBerryFarm)
-- Dollywood (ThemeParks.Parks.Dollywood)
-- Silver Dollar City (ThemeParks.Parks.SilverDollarCity)
-- Seaworld Orlando (ThemeParks.Parks.SeaworldOrlando)
-- Efteling (ThemeParks.Parks.Efteling)
-- Universal Studios Florida (ThemeParks.Parks.UniversalStudiosFlorida)
-- Universal's Islands Of Adventure (ThemeParks.Parks.UniversalIslandsOfAdventure)
-- Universal Volcano Bay (ThemeParks.Parks.UniversalVolcanoBay)
-- Universal Studios Hollywood (ThemeParks.Parks.UniversalStudiosHollywood)
-- Universal Studios Singapore (ThemeParks.Parks.UniversalStudiosSingapore)
-- Universal Studios Japan (ThemeParks.Parks.UniversalStudiosJapan)
-- Six Flags Over Texas (ThemeParks.Parks.SixFlagsOverTexas)
-- Six Flags Over Georgia (ThemeParks.Parks.SixFlagsOverGeorgia)
-- Six Flags St. Louis (ThemeParks.Parks.SixFlagsStLouis)
-- Six Flags Great Adventure (ThemeParks.Parks.SixFlagsGreatAdventure)
-- Six Flags Magic Mountain (ThemeParks.Parks.SixFlagsMagicMountain)
-- Six Flags Great America (ThemeParks.Parks.SixFlagsGreatAmerica)
-- Six Flags Fiesta Texas (ThemeParks.Parks.SixFlagsFiestaTexas)
-- Six Flags Hurricane Harbor, Arlington (ThemeParks.Parks.SixFlagsHurricaneHarborArlington)
-- Six Flags Hurricane Harbor, Los Angeles (ThemeParks.Parks.SixFlagsHurricaneHarborLosAngeles)
-- Six Flags America (ThemeParks.Parks.SixFlagsAmerica)
-- Six Flags Discovery Kingdom (ThemeParks.Parks.SixFlagsDiscoveryKingdom)
-- Six Flags New England (ThemeParks.Parks.SixFlagsNewEngland)
-- Six Flags Hurricane Harbor, Jackson (ThemeParks.Parks.SixFlagsHurricaneHarborJackson)
-- The Great Escape (ThemeParks.Parks.TheGreatEscape)
-- Six Flags White Water, Atlanta (ThemeParks.Parks.SixFlagsWhiteWaterAtlanta)
-- Six Flags México (ThemeParks.Parks.SixFlagsMexico)
-- La Ronde, Montreal (ThemeParks.Parks.LaRondeMontreal)
-- Six Flags Hurricane Harbor, Oaxtepec (ThemeParks.Parks.SixFlagsHurricaneHarborOaxtepec)
-- Six Flags Hurricane Harbor, Concord (ThemeParks.Parks.SixFlagsHurricaneHarborConcord)
-- PortAventura (ThemeParks.Parks.PortAventura)
-- Ferrari Land (ThemeParks.Parks.FerrariLand)
-- Alton Towers (ThemeParks.Parks.AltonTowers)
-- Thorpe Park (ThemeParks.Parks.ThorpePark)
-- Chessington World Of Adventures (ThemeParks.Parks.ChessingtonWorldOfAdventures)
-- Bellewaerde (ThemeParks.Parks.Bellewaerde)
-- Phantasialand (ThemeParks.Parks.Phantasialand)
-- Heidepark (ThemeParks.Parks.HeidePark)
+* Magic Kingdom - Walt Disney World Florida (ThemeParks.Parks.WaltDisneyWorldMagicKingdom)
+* Epcot - Walt Disney World Florida (ThemeParks.Parks.WaltDisneyWorldEpcot)
+* Hollywood Studios - Walt Disney World Florida (ThemeParks.Parks.WaltDisneyWorldHollywoodStudios)
+* Animal Kingdom - Walt Disney World Florida (ThemeParks.Parks.WaltDisneyWorldAnimalKingdom)
+* Magic Kingdom - Disneyland Resort (ThemeParks.Parks.DisneylandResortMagicKingdom)
+* California Adventure - Disneyland Resort (ThemeParks.Parks.DisneylandResortCaliforniaAdventure)
+* Magic Kingdom - Disneyland Paris (ThemeParks.Parks.DisneylandParisMagicKingdom)
+* Walt Disney Studios - Disneyland Paris (ThemeParks.Parks.DisneylandParisWaltDisneyStudios)
+* Hong Kong Disneyland (ThemeParks.Parks.HongKongDisneyland)
+* Magic Kingdom - Shanghai Disney Resort (ThemeParks.Parks.ShanghaiDisneyResortMagicKingdom)
+* Magic Kingdom - Tokyo Disney Resort (ThemeParks.Parks.TokyoDisneyResortMagicKingdom)
+* Disney Sea - Tokyo Disney Resort (ThemeParks.Parks.TokyoDisneyResortDisneySea)
+* Europa Park (ThemeParks.Parks.EuropaPark)
+* Hershey Park (ThemeParks.Parks.HersheyPark)
+* Parc-Asterix (ThemeParks.Parks.AsterixPark)
+* California's Great America (ThemeParks.Parks.CaliforniasGreatAmerica)
+* Canada's Wonderland (ThemeParks.Parks.CanadasWonderland)
+* Carowinds (ThemeParks.Parks.Carowinds)
+* Cedar Point (ThemeParks.Parks.CedarPoint)
+* Kings Island (ThemeParks.Parks.KingsIsland)
+* Knott's Berry Farm (ThemeParks.Parks.KnottsBerryFarm)
+* Dollywood (ThemeParks.Parks.Dollywood)
+* Silver Dollar City (ThemeParks.Parks.SilverDollarCity)
+* Seaworld Orlando (ThemeParks.Parks.SeaworldOrlando)
+* Efteling (ThemeParks.Parks.Efteling)
+* Universal Studios Florida (ThemeParks.Parks.UniversalStudiosFlorida)
+* Universal's Islands Of Adventure (ThemeParks.Parks.UniversalIslandsOfAdventure)
+* Universal Volcano Bay (ThemeParks.Parks.UniversalVolcanoBay)
+* Universal Studios Hollywood (ThemeParks.Parks.UniversalStudiosHollywood)
+* Universal Studios Singapore (ThemeParks.Parks.UniversalStudiosSingapore)
+* Universal Studios Japan (ThemeParks.Parks.UniversalStudiosJapan)
+* Six Flags Over Texas (ThemeParks.Parks.SixFlagsOverTexas)
+* Six Flags Over Georgia (ThemeParks.Parks.SixFlagsOverGeorgia)
+* Six Flags St. Louis (ThemeParks.Parks.SixFlagsStLouis)
+* Six Flags Great Adventure (ThemeParks.Parks.SixFlagsGreatAdventure)
+* Six Flags Magic Mountain (ThemeParks.Parks.SixFlagsMagicMountain)
+* Six Flags Great America (ThemeParks.Parks.SixFlagsGreatAmerica)
+* Six Flags Fiesta Texas (ThemeParks.Parks.SixFlagsFiestaTexas)
+* Six Flags Hurricane Harbor, Arlington (ThemeParks.Parks.SixFlagsHurricaneHarborArlington)
+* Six Flags Hurricane Harbor, Los Angeles (ThemeParks.Parks.SixFlagsHurricaneHarborLosAngeles)
+* Six Flags America (ThemeParks.Parks.SixFlagsAmerica)
+* Six Flags Discovery Kingdom (ThemeParks.Parks.SixFlagsDiscoveryKingdom)
+* Six Flags New England (ThemeParks.Parks.SixFlagsNewEngland)
+* Six Flags Hurricane Harbor, Jackson (ThemeParks.Parks.SixFlagsHurricaneHarborJackson)
+* The Great Escape (ThemeParks.Parks.TheGreatEscape)
+* Six Flags White Water, Atlanta (ThemeParks.Parks.SixFlagsWhiteWaterAtlanta)
+* Six Flags México (ThemeParks.Parks.SixFlagsMexico)
+* La Ronde, Montreal (ThemeParks.Parks.LaRondeMontreal)
+* Six Flags Hurricane Harbor, Oaxtepec (ThemeParks.Parks.SixFlagsHurricaneHarborOaxtepec)
+* Six Flags Hurricane Harbor, Concord (ThemeParks.Parks.SixFlagsHurricaneHarborConcord)
+* PortAventura (ThemeParks.Parks.PortAventura)
+* Ferrari Land (ThemeParks.Parks.FerrariLand)
+* Alton Towers (ThemeParks.Parks.AltonTowers)
+* Thorpe Park (ThemeParks.Parks.ThorpePark)
+* Chessington World Of Adventures (ThemeParks.Parks.ChessingtonWorldOfAdventures)
+* Bellewaerde (ThemeParks.Parks.Bellewaerde)
+* Phantasialand (ThemeParks.Parks.Phantasialand)
+* Heide Park (ThemeParks.Parks.HeidePark)
 
 <!-- END_SUPPORTED_PARKS_LIST -->
 
 ## Supported Park Features
 
 <!-- START_PARK_FEATURES_SUPPORTED -->
-
-| Park                                          | Wait Times | Park Opening Times | Ride Opening Times |
-| :-------------------------------------------- | :--------- | :----------------- | :----------------- |
-| Magic Kingdom - Walt Disney World Florida     | &#10003;   | &#10003;           | &#10007;           |
-| Epcot - Walt Disney World Florida             | &#10003;   | &#10003;           | &#10007;           |
-| Hollywood Studios - Walt Disney World Florida | &#10003;   | &#10003;           | &#10007;           |
-| Animal Kingdom - Walt Disney World Florida    | &#10003;   | &#10003;           | &#10007;           |
-| Magic Kingdom - Disneyland Resort             | &#10003;   | &#10003;           | &#10007;           |
-| California Adventure - Disneyland Resort      | &#10003;   | &#10003;           | &#10007;           |
-| Magic Kingdom - Disneyland Paris              | &#10003;   | &#10003;           | &#10007;           |
-| Walt Disney Studios - Disneyland Paris        | &#10003;   | &#10003;           | &#10007;           |
-| Hong Kong Disneyland                          | &#10003;   | &#10003;           | &#10007;           |
-| Magic Kingdom - Shanghai Disney Resort        | &#10003;   | &#10003;           | &#10007;           |
-| Magic Kingdom - Tokyo Disney Resort           | &#10003;   | &#10003;           | &#10007;           |
-| Disney Sea - Tokyo Disney Resort              | &#10003;   | &#10003;           | &#10007;           |
-| Europa Park                                   | &#10003;   | &#10003;           | &#10007;           |
-| Hershey Park                                  | &#10003;   | &#10003;           | &#10007;           |
-| Parc-Asterix                                  | &#10003;   | &#10003;           | &#10003;           |
-| California's Great America                    | &#10003;   | &#10003;           | &#10007;           |
-| Canada's Wonderland                           | &#10003;   | &#10003;           | &#10007;           |
-| Carowinds                                     | &#10003;   | &#10003;           | &#10007;           |
-| Cedar Point                                   | &#10003;   | &#10003;           | &#10007;           |
-| Kings Island                                  | &#10003;   | &#10003;           | &#10007;           |
-| Knott's Berry Farm                            | &#10003;   | &#10003;           | &#10007;           |
-| Dollywood                                     | &#10003;   | &#10003;           | &#10007;           |
-| Silver Dollar City                            | &#10003;   | &#10003;           | &#10007;           |
-| Seaworld Orlando                              | &#10003;   | &#10003;           | &#10007;           |
-| Efteling                                      | &#10003;   | &#10003;           | &#10007;           |
-| Universal Studios Florida                     | &#10003;   | &#10003;           | &#10007;           |
-| Universal's Islands Of Adventure              | &#10003;   | &#10003;           | &#10007;           |
-| Universal Volcano Bay                         | &#10003;   | &#10003;           | &#10007;           |
-| Universal Studios Hollywood                   | &#10003;   | &#10003;           | &#10007;           |
-| Universal Studios Singapore                   | &#10003;   | &#10003;           | &#10007;           |
-| Universal Studios Japan                       | &#10003;   | &#10003;           | &#10007;           |
-| Six Flags Over Texas                          | &#10003;   | &#10003;           | &#10007;           |
-| Six Flags Over Georgia                        | &#10003;   | &#10003;           | &#10007;           |
-| Six Flags St. Louis                           | &#10003;   | &#10003;           | &#10007;           |
-| Six Flags Great Adventure                     | &#10003;   | &#10003;           | &#10007;           |
-| Six Flags Magic Mountain                      | &#10003;   | &#10003;           | &#10007;           |
-| Six Flags Great America                       | &#10003;   | &#10003;           | &#10007;           |
-| Six Flags Fiesta Texas                        | &#10003;   | &#10003;           | &#10007;           |
-| Six Flags Hurricane Harbor, Arlington         | &#10003;   | &#10003;           | &#10007;           |
-| Six Flags Hurricane Harbor, Los Angeles       | &#10003;   | &#10003;           | &#10007;           |
-| Six Flags America                             | &#10003;   | &#10003;           | &#10007;           |
-| Six Flags Discovery Kingdom                   | &#10003;   | &#10003;           | &#10007;           |
-| Six Flags New England                         | &#10003;   | &#10003;           | &#10007;           |
-| Six Flags Hurricane Harbor, Jackson           | &#10003;   | &#10003;           | &#10007;           |
-| The Great Escape                              | &#10003;   | &#10003;           | &#10007;           |
-| Six Flags White Water, Atlanta                | &#10003;   | &#10003;           | &#10007;           |
-| Six Flags México                              | &#10003;   | &#10003;           | &#10007;           |
-| La Ronde, Montreal                            | &#10003;   | &#10003;           | &#10007;           |
-| Six Flags Hurricane Harbor, Oaxtepec          | &#10003;   | &#10003;           | &#10007;           |
-| Six Flags Hurricane Harbor, Concord           | &#10003;   | &#10003;           | &#10007;           |
-| PortAventura                                  | &#10003;   | &#10003;           | &#10007;           |
-| Ferrari Land                                  | &#10003;   | &#10003;           | &#10007;           |
-| Alton Towers                                  | &#10003;   | &#10003;           | &#10007;           |
-| Thorpe Park                                   | &#10003;   | &#10003;           | &#10007;           |
-| Chessington World Of Adventures               | &#10003;   | &#10003;           | &#10007;           |
-| Bellewaerde                                   | &#10003;   | &#10003;           | &#10007;           |
-| Phantasialand                                 | &#10003;   | &#10003;           | &#10007;           |
-| HeidePark                                     | &#10003;   | &#10003;           | &#10007;           |
+|Park|Wait Times|Park Opening Times|Ride Opening Times|
+|:---|:---------|:-----------------|:-----------------|
+|Magic Kingdom - Walt Disney World Florida|&#10003;|&#10003;|&#10007;|
+|Epcot - Walt Disney World Florida|&#10003;|&#10003;|&#10007;|
+|Hollywood Studios - Walt Disney World Florida|&#10003;|&#10003;|&#10007;|
+|Animal Kingdom - Walt Disney World Florida|&#10003;|&#10003;|&#10007;|
+|Magic Kingdom - Disneyland Resort|&#10003;|&#10003;|&#10007;|
+|California Adventure - Disneyland Resort|&#10003;|&#10003;|&#10007;|
+|Magic Kingdom - Disneyland Paris|&#10003;|&#10003;|&#10007;|
+|Walt Disney Studios - Disneyland Paris|&#10003;|&#10003;|&#10007;|
+|Hong Kong Disneyland|&#10003;|&#10003;|&#10007;|
+|Magic Kingdom - Shanghai Disney Resort|&#10003;|&#10003;|&#10007;|
+|Magic Kingdom - Tokyo Disney Resort|&#10003;|&#10003;|&#10007;|
+|Disney Sea - Tokyo Disney Resort|&#10003;|&#10003;|&#10007;|
+|Europa Park|&#10003;|&#10003;|&#10007;|
+|Hershey Park|&#10003;|&#10003;|&#10007;|
+|Parc-Asterix|&#10003;|&#10003;|&#10003;|
+|California's Great America|&#10003;|&#10003;|&#10007;|
+|Canada's Wonderland|&#10003;|&#10003;|&#10007;|
+|Carowinds|&#10003;|&#10003;|&#10007;|
+|Cedar Point|&#10003;|&#10003;|&#10007;|
+|Kings Island|&#10003;|&#10003;|&#10007;|
+|Knott's Berry Farm|&#10003;|&#10003;|&#10007;|
+|Dollywood|&#10003;|&#10003;|&#10007;|
+|Silver Dollar City|&#10003;|&#10003;|&#10007;|
+|Seaworld Orlando|&#10003;|&#10003;|&#10007;|
+|Efteling|&#10003;|&#10003;|&#10007;|
+|Universal Studios Florida|&#10003;|&#10003;|&#10007;|
+|Universal's Islands Of Adventure|&#10003;|&#10003;|&#10007;|
+|Universal Volcano Bay|&#10003;|&#10003;|&#10007;|
+|Universal Studios Hollywood|&#10003;|&#10003;|&#10007;|
+|Universal Studios Singapore|&#10003;|&#10003;|&#10007;|
+|Universal Studios Japan|&#10003;|&#10003;|&#10007;|
+|Six Flags Over Texas|&#10003;|&#10003;|&#10007;|
+|Six Flags Over Georgia|&#10003;|&#10003;|&#10007;|
+|Six Flags St. Louis|&#10003;|&#10003;|&#10007;|
+|Six Flags Great Adventure|&#10003;|&#10003;|&#10007;|
+|Six Flags Magic Mountain|&#10003;|&#10003;|&#10007;|
+|Six Flags Great America|&#10003;|&#10003;|&#10007;|
+|Six Flags Fiesta Texas|&#10003;|&#10003;|&#10007;|
+|Six Flags Hurricane Harbor, Arlington|&#10003;|&#10003;|&#10007;|
+|Six Flags Hurricane Harbor, Los Angeles|&#10003;|&#10003;|&#10007;|
+|Six Flags America|&#10003;|&#10003;|&#10007;|
+|Six Flags Discovery Kingdom|&#10003;|&#10003;|&#10007;|
+|Six Flags New England|&#10003;|&#10003;|&#10007;|
+|Six Flags Hurricane Harbor, Jackson|&#10003;|&#10003;|&#10007;|
+|The Great Escape|&#10003;|&#10003;|&#10007;|
+|Six Flags White Water, Atlanta|&#10003;|&#10003;|&#10007;|
+|Six Flags México|&#10003;|&#10003;|&#10007;|
+|La Ronde, Montreal|&#10003;|&#10003;|&#10007;|
+|Six Flags Hurricane Harbor, Oaxtepec|&#10003;|&#10003;|&#10007;|
+|Six Flags Hurricane Harbor, Concord|&#10003;|&#10003;|&#10007;|
+|PortAventura|&#10003;|&#10003;|&#10007;|
+|Ferrari Land|&#10003;|&#10003;|&#10007;|
+|Alton Towers|&#10003;|&#10003;|&#10007;|
+|Thorpe Park|&#10003;|&#10003;|&#10007;|
+|Chessington World Of Adventures|&#10003;|&#10003;|&#10007;|
+|Bellewaerde|&#10003;|&#10003;|&#10007;|
+|Phantasialand|&#10003;|&#10003;|&#10007;|
+|Heide Park|&#10003;|&#10003;|&#10007;|
 
 <!-- END_PARK_FEATURES_SUPPORTED -->
 
@@ -302,64 +301,64 @@ Prints:
 
 <!-- START_PARK_TIMEZONE_LIST -->
 
-- Magic Kingdom - Walt Disney World Florida [(28°23′6.72″N, 81°33′50.04″W)]: (America/New_York)
-- Epcot - Walt Disney World Florida [(28°22′28.92″N, 81°32′57.84″W)]: (America/New_York)
-- Hollywood Studios - Walt Disney World Florida [(28°21′27.00″N, 81°33′29.52″W)]: (America/New_York)
-- Animal Kingdom - Walt Disney World Florida [(28°21′19.08″N, 81°35′24.36″W)]: (America/New_York)
-- Magic Kingdom - Disneyland Resort [(33°48′36.39″N, 117°55′8.30″W)]: (America/Los_Angeles)
-- California Adventure - Disneyland Resort [(33°48′31.39″N, 117°55′8.36″W)]: (America/Los_Angeles)
-- Magic Kingdom - Disneyland Paris [(48°52′13.16″N, 2°46′46.82″E)]: (Europe/Paris)
-- Walt Disney Studios - Disneyland Paris [(48°52′5.78″N, 2°46′50.59″E)]: (Europe/Paris)
-- Hong Kong Disneyland [(22°18′47.52″N, 114°2′40.20″E)]: (Asia/Hong_Kong)
-- Magic Kingdom - Shanghai Disney Resort [(31°8′35.88″N, 121°39′28.80″E)]: (Asia/Shanghai)
-- Magic Kingdom - Tokyo Disney Resort [(35°38′5.45″N, 139°52′45.46″E)]: (Asia/Tokyo)
-- Disney Sea - Tokyo Disney Resort [(35°37′37.40″N, 139°53′20.75″E)]: (Asia/Tokyo)
-- Europa Park [(48°16′8.15″N, 7°43′17.61″E)]: (Europe/Berlin)
-- Hershey Park [(40°17′15.65″N, 76°39′30.88″W)]: (America/New_York)
-- Parc-Asterix [(49°8′9.75″N, 2°34′21.96″E)]: (Europe/Paris)
-- California's Great America [(37°23′52.08″N, 121°58′28.98″W)]: (America/Los_Angeles)
-- Canada's Wonderland [(43°50′34.80″N, 79°32′20.40″W)]: (America/Toronto)
-- Carowinds [(35°6′16.20″N, 80°56′21.84″W)]: (America/New_York)
-- Cedar Point [(41°28′42.24″N, 82°40′45.48″W)]: (America/New_York)
-- Kings Island [(39°20′40.92″N, 84°16′6.96″W)]: (America/New_York)
-- Knott's Berry Farm [(33°50′39.12″N, 117°59′54.96″W)]: (America/Los_Angeles)
-- Dollywood [(35°47′43.18″N, 83°31′51.19″W)]: (America/New_York)
-- Silver Dollar City [(36°40′5.44″N, 93°20′18.84″W)]: (America/Chicago)
-- Seaworld Orlando [(28°24′41.40″N, 81°27′48.24″W)]: (America/New_York)
-- Efteling [(51°38′59.67″N, 5°2′36.82″E)]: (Europe/Amsterdam)
-- Universal Studios Florida [(28°28′29.94″N, 81°27′59.39″W)]: (America/New_York)
-- Universal's Islands Of Adventure [(28°28′20.07″N, 81°28′4.28″W)]: (America/New_York)
-- Universal Volcano Bay [(28°27′44.28″N, 81°28′14.52″W)]: (America/New_York)
-- Universal Studios Hollywood [(34°8′14.14″N, 118°21′19.86″W)]: (America/Los_Angeles)
-- Universal Studios Singapore [(1°15′15.30″N, 103°49′25.67″E)]: (Asia/Singapore)
-- Universal Studios Japan [(34°39′55.74″N, 135°25′56.50″E)]: (Asia/Tokyo)
-- Six Flags Over Texas [(32°45′17.95″N, 97°4′13.33″W)]: (America/Chicago)
-- Six Flags Over Georgia [(33°46′14.08″N, 84°33′5.36″W)]: (America/New_York)
-- Six Flags St. Louis [(38°30′47.61″N, 90°40′30.69″W)]: (America/Chicago)
-- Six Flags Great Adventure [(40°8′55.18″N, 74°26′27.69″W)]: (America/New_York)
-- Six Flags Magic Mountain [(34°25′24.46″N, 118°35′42.90″W)]: (America/Los_Angeles)
-- Six Flags Great America [(42°22′12.88″N, 87°56′9.30″W)]: (America/Chicago)
-- Six Flags Fiesta Texas [(29°35′59.28″N, 98°36′32.50″W)]: (America/Chicago)
-- Six Flags Hurricane Harbor, Arlington [(32°45′43.20″N, 97°4′58.44″W)]: (America/Chicago)
-- Six Flags Hurricane Harbor, Los Angeles [(34°25′25.86″N, 118°35′42.05″W)]: (America/Los_Angeles)
-- Six Flags America [(38°54′4.46″N, 76°46′16.59″W)]: (America/New_York)
-- Six Flags Discovery Kingdom [(38°8′19.43″N, 122°13′59.70″W)]: (America/Los_Angeles)
-- Six Flags New England [(42°2′16.54″N, 72°36′55.92″W)]: (America/New_York)
-- Six Flags Hurricane Harbor, Jackson [(40°8′18.24″N, 74°26′25.80″W)]: (America/New_York)
-- The Great Escape [(43°21′1.80″N, 73°41′32.10″W)]: (America/New_York)
-- Six Flags White Water, Atlanta [(33°57′32.86″N, 84°31′10.37″W)]: (America/New_York)
-- Six Flags México [(19°17′43.40″N, 99°12′41.19″W)]: (America/Mexico_City)
-- La Ronde, Montreal [(45°31′19.18″N, 73°32′4.48″W)]: (America/Toronto)
-- Six Flags Hurricane Harbor, Oaxtepec [(18°53′48.12″N, 98°58′31.44″W)]: (America/Mexico_City)
-- Six Flags Hurricane Harbor, Concord [(37°58′23.89″N, 122°3′1.98″W)]: (America/Los_Angeles)
-- PortAventura [(41°5′11.24″N, 1°9′13.14″E)]: (Europe/Madrid)
-- Ferrari Land [(41°5′10.08″N, 1°9′11.67″E)]: (Europe/Madrid)
-- Alton Towers [(52°59′27.83″N, 1°53′32.25″W)]: (Europe/London)
-- Thorpe Park [(51°24′19.80″N, 0°30′37.80″W)]: (Europe/London)
-- Chessington World Of Adventures [(51°20′58.56″N, 0°18′52.45″W)]: (Europe/London)
-- Bellewaerde [(50°50′49.19″N, 2°56′52.61″E)]: (Europe/Brussels)
-- Phantasialand [(50°47′56.23″N, 6°52′45.53″E)]: (Europe/Berlin)
-- HeidePark [(53°01′28.7″N, 9°52′25.7″E)]: (Europe/Berlin)
+* Magic Kingdom - Walt Disney World Florida [(28°23′6.72″N, 81°33′50.04″W)]: (America/New_York)
+* Epcot - Walt Disney World Florida [(28°22′28.92″N, 81°32′57.84″W)]: (America/New_York)
+* Hollywood Studios - Walt Disney World Florida [(28°21′27.00″N, 81°33′29.52″W)]: (America/New_York)
+* Animal Kingdom - Walt Disney World Florida [(28°21′19.08″N, 81°35′24.36″W)]: (America/New_York)
+* Magic Kingdom - Disneyland Resort [(33°48′36.39″N, 117°55′8.30″W)]: (America/Los_Angeles)
+* California Adventure - Disneyland Resort [(33°48′31.39″N, 117°55′8.36″W)]: (America/Los_Angeles)
+* Magic Kingdom - Disneyland Paris [(48°52′13.16″N, 2°46′46.82″E)]: (Europe/Paris)
+* Walt Disney Studios - Disneyland Paris [(48°52′5.78″N, 2°46′50.59″E)]: (Europe/Paris)
+* Hong Kong Disneyland [(22°18′47.52″N, 114°2′40.20″E)]: (Asia/Hong_Kong)
+* Magic Kingdom - Shanghai Disney Resort [(31°8′35.88″N, 121°39′28.80″E)]: (Asia/Shanghai)
+* Magic Kingdom - Tokyo Disney Resort [(35°38′5.45″N, 139°52′45.46″E)]: (Asia/Tokyo)
+* Disney Sea - Tokyo Disney Resort [(35°37′37.40″N, 139°53′20.75″E)]: (Asia/Tokyo)
+* Europa Park [(48°16′8.15″N, 7°43′17.61″E)]: (Europe/Berlin)
+* Hershey Park [(40°17′15.65″N, 76°39′30.88″W)]: (America/New_York)
+* Parc-Asterix [(49°8′9.75″N, 2°34′21.96″E)]: (Europe/Paris)
+* California's Great America [(37°23′52.08″N, 121°58′28.98″W)]: (America/Los_Angeles)
+* Canada's Wonderland [(43°50′34.80″N, 79°32′20.40″W)]: (America/Toronto)
+* Carowinds [(35°6′16.20″N, 80°56′21.84″W)]: (America/New_York)
+* Cedar Point [(41°28′42.24″N, 82°40′45.48″W)]: (America/New_York)
+* Kings Island [(39°20′40.92″N, 84°16′6.96″W)]: (America/New_York)
+* Knott's Berry Farm [(33°50′39.12″N, 117°59′54.96″W)]: (America/Los_Angeles)
+* Dollywood [(35°47′43.18″N, 83°31′51.19″W)]: (America/New_York)
+* Silver Dollar City [(36°40′5.44″N, 93°20′18.84″W)]: (America/Chicago)
+* Seaworld Orlando [(28°24′41.40″N, 81°27′48.24″W)]: (America/New_York)
+* Efteling [(51°38′59.67″N, 5°2′36.82″E)]: (Europe/Amsterdam)
+* Universal Studios Florida [(28°28′29.94″N, 81°27′59.39″W)]: (America/New_York)
+* Universal's Islands Of Adventure [(28°28′20.07″N, 81°28′4.28″W)]: (America/New_York)
+* Universal Volcano Bay [(28°27′44.28″N, 81°28′14.52″W)]: (America/New_York)
+* Universal Studios Hollywood [(34°8′14.14″N, 118°21′19.86″W)]: (America/Los_Angeles)
+* Universal Studios Singapore [(1°15′15.30″N, 103°49′25.67″E)]: (Asia/Singapore)
+* Universal Studios Japan [(34°39′55.74″N, 135°25′56.50″E)]: (Asia/Tokyo)
+* Six Flags Over Texas [(32°45′17.95″N, 97°4′13.33″W)]: (America/Chicago)
+* Six Flags Over Georgia [(33°46′14.08″N, 84°33′5.36″W)]: (America/New_York)
+* Six Flags St. Louis [(38°30′47.61″N, 90°40′30.69″W)]: (America/Chicago)
+* Six Flags Great Adventure [(40°8′55.18″N, 74°26′27.69″W)]: (America/New_York)
+* Six Flags Magic Mountain [(34°25′24.46″N, 118°35′42.90″W)]: (America/Los_Angeles)
+* Six Flags Great America [(42°22′12.88″N, 87°56′9.30″W)]: (America/Chicago)
+* Six Flags Fiesta Texas [(29°35′59.28″N, 98°36′32.50″W)]: (America/Chicago)
+* Six Flags Hurricane Harbor, Arlington [(32°45′43.20″N, 97°4′58.44″W)]: (America/Chicago)
+* Six Flags Hurricane Harbor, Los Angeles [(34°25′25.86″N, 118°35′42.05″W)]: (America/Los_Angeles)
+* Six Flags America [(38°54′4.46″N, 76°46′16.59″W)]: (America/New_York)
+* Six Flags Discovery Kingdom [(38°8′19.43″N, 122°13′59.70″W)]: (America/Los_Angeles)
+* Six Flags New England [(42°2′16.54″N, 72°36′55.92″W)]: (America/New_York)
+* Six Flags Hurricane Harbor, Jackson [(40°8′18.24″N, 74°26′25.80″W)]: (America/New_York)
+* The Great Escape [(43°21′1.80″N, 73°41′32.10″W)]: (America/New_York)
+* Six Flags White Water, Atlanta [(33°57′32.86″N, 84°31′10.37″W)]: (America/New_York)
+* Six Flags México [(19°17′43.40″N, 99°12′41.19″W)]: (America/Mexico_City)
+* La Ronde, Montreal [(45°31′19.18″N, 73°32′4.48″W)]: (America/Toronto)
+* Six Flags Hurricane Harbor, Oaxtepec [(18°53′48.12″N, 98°58′31.44″W)]: (America/Mexico_City)
+* Six Flags Hurricane Harbor, Concord [(37°58′23.89″N, 122°3′1.98″W)]: (America/Los_Angeles)
+* PortAventura [(41°5′11.24″N, 1°9′13.14″E)]: (Europe/Madrid)
+* Ferrari Land [(41°5′10.08″N, 1°9′11.67″E)]: (Europe/Madrid)
+* Alton Towers [(52°59′27.83″N, 1°53′32.25″W)]: (Europe/London)
+* Thorpe Park [(51°24′19.80″N, 0°30′37.80″W)]: (Europe/London)
+* Chessington World Of Adventures [(51°20′58.56″N, 0°18′52.45″W)]: (Europe/London)
+* Bellewaerde [(50°50′49.19″N, 2°56′52.61″E)]: (Europe/Brussels)
+* Phantasialand [(50°47′56.23″N, 6°52′45.53″E)]: (Europe/Berlin)
+* Heide Park [(53°1′28.72″N, 9°52′17.78″E)]: (Europe/Berlin)
 
 <!-- END_PARK_TIMEZONE_LIST -->
 

--- a/lib/heidepark/heidepark.js
+++ b/lib/heidepark/heidepark.js
@@ -1,0 +1,192 @@
+// include core Park class
+const Moment = require('moment-timezone');
+const cheerio = require('cheerio');
+const Park = require('../park');
+
+const sApiBase = Symbol('Heide Park API Base URL');
+const sApiVersion = Symbol('Heide Park API Version');
+const sOpeningHoursUrl = Symbol('Heide Park Openinghours Url');
+
+class HeidePark extends Park {
+  constructor(options = {}) {
+    options.name = options.name || 'Heide Park';
+
+    // Heide Park Resort from Google maps
+    options.latitude = options.latitude || 53.0246445;
+    options.longitude = options.longitude || 9.8716046;
+
+    // Use the Android app's user-agent
+    options.useragent = options.useragent || 'okhttp/3.9.1';
+
+    // park's timezone
+    options.timezone = 'Europe/Berlin';
+
+    // inherit from base class
+    super(options);
+
+    // accept overriding the API base URL
+    this[sApiBase] = options.apiBase || 'https://www.heide-park.de/api/';
+    // accept overriding the OpeingHours Url
+    this[sOpeningHoursUrl] = options.OpeningHoursUrl || 'https://www.heide-park.de/infos/oeffnungszeiten-anreise.html';
+    // accept overriding API version
+    this[sApiVersion] = options.apiVersion || 'v4';
+  }
+
+  /**
+   * Parses the special events from the API Response
+   * @param {Object} events Events in the API Response
+   */
+  addEvents(events) {
+    events.forEach((event) => {
+      const rideUpdate = {
+        waitTime: 0,
+        name: event.event_title ? event.event_title : '???',
+        meta: {
+          type: 'event',
+          eventBody: event.event_body,
+          eventLink: event.event_link,
+          eventTeaserImg: event.event_teaser_img,
+          eventImages: event.event_images,
+        },
+      };
+      this.UpdateRide(rideUpdate.name, rideUpdate);
+    });
+  }
+
+  /**
+   * Checks the names from the api if the ride has fastpass
+   * @param {String} name the ridename from the API Response
+   */
+  hasRideFastPass(name) {
+    // this was taken from the park website
+    switch (name) {
+      case 'colossos':
+      case 'flug_der_daemonen':
+      case 'krake':
+      case 'desert_race':
+      case 'scream':
+      case 'big_loop':
+      case 'limit':
+      case 'bobbahn':
+      case 'grottenblitz':
+      case 'wildwasserbahn':
+      case 'ghostbusters':
+        return true;
+
+      default:
+        return false;
+    }
+  }
+
+  /**
+   * parses the Heidepark timeEntries and updates the rides
+   * @param {Object[]} timeEntries A timeEntries Object Array from the API
+   * @param {String} type The Type of the timeEntries 'ride' | 'catering
+   */
+  updateHeideParkTimeEntries(timeEntries, type) {
+    timeEntries.forEach((ride) => {
+      const rideUpdate = {
+        waitTime: -1,
+        active: false,
+        status: 'Closed',
+        name: ride.alias ? ride.alias : '???',
+        fastPass: this.hasRideFastPass(ride.alias ? ride.alias : '???'),
+        meta: {
+          type,
+        },
+      };
+
+      if (ride.type === 'red') {
+        // closed
+      } else if (ride.type === 'time') {
+        // waittime string in format "10 <small>Min.<\/small>"
+        const waittimeArr = ride.msg.match(/(^\d*)\s/);
+        rideUpdate.waitTime = waittimeArr ? parseInt(waittimeArr[1], 10) : 0;
+        rideUpdate.active = true;
+        rideUpdate.status = 'Operating';
+      } else if (ride.type === 'yellow') {
+        // no waittime but operating hours ( for catering as far as is saw it )
+        const openingHoursArr = ride.msg.match(/(\d*)-(\d*)/);
+        const openingHours = Moment().set({
+          hours: openingHoursArr[1], minute: 0, second: 0, millisecond: 0,
+        });
+        const closingHours = Moment().set({
+          hours: openingHoursArr[2], minute: 0, second: 0, millisecond: 0,
+        });
+        rideUpdate.waitTime = 0;
+        rideUpdate.active = true;
+        rideUpdate.status = 'Operating';
+        rideUpdate.meta.openingHours = openingHours;
+        rideUpdate.meta.closingHours = closingHours;
+      }
+      this.UpdateRide(rideUpdate.name, rideUpdate);
+    });
+  }
+
+  FetchWaitTimes() {
+    return this.HTTP({
+      url: `${this[sApiBase]}${this[sApiVersion]}`,
+      returnFullResponse: true,
+      mock: 'heideParkWaitTimes',
+    }).then((parkData) => {
+      let result = parkData.body.replace(/^\(/, '');
+      result = JSON.parse(result.replace(/\);$/, ''));
+      this.updateHeideParkTimeEntries(result.attractions.time_entries, 'ride');
+      this.updateHeideParkTimeEntries(result.catering.time_entries, 'catering');
+      this.addEvents(result.todaybox.events);
+      return Promise.resolve();
+    });
+  }
+
+  /**
+   * parses the openingtimes from the cherio objects and updates the schedule
+   * @param {Object} $ The loaded cheerio object
+   * @param {String} date the date string in format YYYY-MM-DD
+   * @param {Object} hours the found openingtimes cheerio nodes
+   * @param {Object} labels the found label cheerio nodes
+   */
+  updateParkOpeningHours($, date, hours, labels) {
+    const schedule = {
+      date: Moment.tz(date, 'YYYY-MM-DD', this.Timezone),
+      type: 'Closed',
+    };
+    Object.keys(hours).forEach((key) => {
+      if ($(labels[key]).text() === 'Park:') {
+        const openingHours = $(hours[key]).text().match(/(\d*)\s-\s(\d*)/);
+        schedule.openingTime = Moment.tz(`${date} ${openingHours[1]}:00`, 'YYYY-MM-DD HH:mm', this.Timezone);
+        schedule.closingTime = Moment.tz(`${date} ${openingHours[2]}:00`, 'YYYY-MM-DD HH:mm', this.Timezone);
+        schedule.type = 'Operating';
+      }
+    });
+    this.Schedule.SetDate(schedule);
+  }
+
+  FetchOpeningTimes() {
+    return this.HTTP({
+      url: `${this[sOpeningHoursUrl]}`,
+      returnFullResponse: true,
+      mock: 'heideParkOpeningTimes',
+    }).then((openingHoursHtmlPage) => {
+      const $ = cheerio.load(openingHoursHtmlPage.body);
+      const calendar = $('.cal');
+      Object.keys(calendar).forEach((key) => {
+        if (!Number.isNaN(parseInt(key, 10))) {
+          const dayObj = $(calendar[key]).find('.js-cal-day-content');
+          Object.keys(dayObj).forEach((dayKey) => {
+            if (!Number.isNaN(parseInt(dayKey, 10))) {
+              const date = $(dayObj[dayKey]).find('.day-info__header').text();
+              const dateArr = date.match(/(\d*)\.(\d*)\.(\d*)/);
+              const openingHours = $(dayObj[dayKey]).find('.day-info__hours');
+              const openingLabels = $(dayObj[dayKey]).find('.day-info__label');
+              this.updateParkOpeningHours($, `${dateArr[3]}-${dateArr[2]}-${dateArr[1]}`, openingHours, openingLabels);
+            }
+          });
+        }
+      });
+      return Promise.resolve();
+    });
+  }
+}
+
+// export the class
+module.exports = HeidePark;

--- a/lib/heidepark/heidepark.js
+++ b/lib/heidepark/heidepark.js
@@ -7,6 +7,20 @@ const sApiBase = Symbol('Heide Park API Base URL');
 const sApiVersion = Symbol('Heide Park API Version');
 const sOpeningHoursUrl = Symbol('Heide Park Openinghours Url');
 
+const fastPassRides = [
+  'colossos',
+  'flug_der_daemonen',
+  'krake',
+  'desert_race',
+  'scream',
+  'big_loop',
+  'limit',
+  'bobbahn',
+  'grottenblitz',
+  'wildwasserbahn',
+  'ghostbusters',
+];
+
 class HeidePark extends Park {
   constructor(options = {}) {
     options.name = options.name || 'Heide Park';
@@ -33,67 +47,18 @@ class HeidePark extends Park {
   }
 
   /**
-   * Parses the special events from the API Response
-   * @param {Object} events Events in the API Response
-   */
-  addEvents(events) {
-    events.forEach((event) => {
-      const rideUpdate = {
-        waitTime: 0,
-        name: event.event_title ? event.event_title : '???',
-        meta: {
-          type: 'event',
-          eventBody: event.event_body,
-          eventLink: event.event_link,
-          eventTeaserImg: event.event_teaser_img,
-          eventImages: event.event_images,
-        },
-      };
-      this.UpdateRide(rideUpdate.name, rideUpdate);
-    });
-  }
-
-  /**
-   * Checks the names from the api if the ride has fastpass
-   * @param {String} name the ridename from the API Response
-   */
-  hasRideFastPass(name) {
-    // this was taken from the park website
-    switch (name) {
-      case 'colossos':
-      case 'flug_der_daemonen':
-      case 'krake':
-      case 'desert_race':
-      case 'scream':
-      case 'big_loop':
-      case 'limit':
-      case 'bobbahn':
-      case 'grottenblitz':
-      case 'wildwasserbahn':
-      case 'ghostbusters':
-        return true;
-
-      default:
-        return false;
-    }
-  }
-
-  /**
    * parses the Heidepark timeEntries and updates the rides
    * @param {Object[]} timeEntries A timeEntries Object Array from the API
    * @param {String} type The Type of the timeEntries 'ride' | 'catering
    */
-  updateHeideParkTimeEntries(timeEntries, type) {
+  updateHeideParkTimeEntries(timeEntries) {
     timeEntries.forEach((ride) => {
       const rideUpdate = {
         waitTime: -1,
         active: false,
         status: 'Closed',
         name: ride.alias ? ride.alias : '???',
-        fastPass: this.hasRideFastPass(ride.alias ? ride.alias : '???'),
-        meta: {
-          type,
-        },
+        fastPass: fastPassRides.indexOf(ride.alias ? ride.alias : '???') >= 0,
       };
 
       if (ride.type === 'red') {
@@ -104,20 +69,6 @@ class HeidePark extends Park {
         rideUpdate.waitTime = waittimeArr ? parseInt(waittimeArr[1], 10) : 0;
         rideUpdate.active = true;
         rideUpdate.status = 'Operating';
-      } else if (ride.type === 'yellow') {
-        // no waittime but operating hours ( for catering as far as is saw it )
-        const openingHoursArr = ride.msg.match(/(\d*)-(\d*)/);
-        const openingHours = Moment().set({
-          hours: openingHoursArr[1], minute: 0, second: 0, millisecond: 0,
-        });
-        const closingHours = Moment().set({
-          hours: openingHoursArr[2], minute: 0, second: 0, millisecond: 0,
-        });
-        rideUpdate.waitTime = 0;
-        rideUpdate.active = true;
-        rideUpdate.status = 'Operating';
-        rideUpdate.meta.openingHours = openingHours;
-        rideUpdate.meta.closingHours = closingHours;
       }
       this.UpdateRide(rideUpdate.name, rideUpdate);
     });
@@ -132,8 +83,6 @@ class HeidePark extends Park {
       let result = parkData.body.replace(/^\(/, '');
       result = JSON.parse(result.replace(/\);$/, ''));
       this.updateHeideParkTimeEntries(result.attractions.time_entries, 'ride');
-      this.updateHeideParkTimeEntries(result.catering.time_entries, 'catering');
-      this.addEvents(result.todaybox.events);
       return Promise.resolve();
     });
   }
@@ -159,6 +108,18 @@ class HeidePark extends Park {
       }
     });
     this.Schedule.SetDate(schedule);
+    // check for special hours
+    Object.keys(labels).forEach((labelKey) => {
+      if (!Number.isNaN(parseInt(labelKey, 10))) {
+        const specialHour = $(labels[labelKey]).find('a');
+        if (specialHour && specialHour.text() !== '') {
+          // add specialHour
+          schedule.type = specialHour.text().trim();
+          schedule.specialHours = true;
+          this.Schedule.SetDate(schedule);
+        }
+      }
+    });
   }
 
   FetchOpeningTimes() {

--- a/lib/index.js
+++ b/lib/index.js
@@ -82,6 +82,8 @@ const ChessingtonWorldOfAdventures = require('./merlinparks/chessingtonworldofad
 const Bellewaerde = require('./bellewaerde/bellewaerde');
 // Phantasialand
 const Phantasialand = require('./phantasialand/phantasialand');
+// Heidepark
+const HeidePark = require('./heidepark/heidepark');
 
 // === Expose Parks ===
 
@@ -167,6 +169,8 @@ exports.AllParks = [
   Bellewaerde,
   // Phantasialand
   Phantasialand,
+  // Heidepark
+  HeidePark,
 ];
 
 // export all parks by name in a JavaScript object too
@@ -250,4 +254,6 @@ exports.Parks = {
   Bellewaerde,
   // Phantasialand
   Phantasialand,
+  // Heidepark
+  HeidePark,
 };

--- a/lib/mocks/heideParkOpeningTimes.mock
+++ b/lib/mocks/heideParkOpeningTimes.mock
@@ -1,0 +1,1969 @@
+<!doctype html>
+<!--[if lt IE 7]> <html lang="de" class="lang-de oldie no-js ie lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
+<!--[if IE 7]> <html lang="de" class="lang-de oldie no-js ie lt-ie9 lt-ie8"> <![endif]-->
+<!--[if IE 8]> <html lang="de" class="lang-de oldie no-js ie lt-ie9"> <![endif]-->
+<!--[if IE 9]> <html lang="de" class="lang-de no-js ie lt-ie10"> <![endif]-->
+<!--[if gt IE 9]><!-->
+<html lang="de" class="lang-de no-js">
+<!--<![endif]-->
+
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <!-- This website is powered by TYPO3 - inspiring people to share! TYPO3 is a free open source Content Management Framework initially created by Kasper Skaarhoj and licensed under GNU/GPL. TYPO3 is copyright 1998-2019 of Kasper Skaarhoj. Extensions are copyright of their respective owners. Information and contribution at https://typo3.org/ -->
+    <meta name="generator" content="TYPO3 CMS">
+    <meta name="robots" content="INDEX,FOLLOW">
+    <meta name="canonical" content="https://www.heide-park.de/infos/oeffnungszeiten-anreise.html">
+    <meta name="X-UA-Compatible" content="IE=edge,chrome=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
+    <meta name="description" content="Seht auf einen Blick alle Öffnungszeiten des Heide Park Resorts: Innerhalb der Saison auch an Feiertagen geöffnet! Beachtet die Sonderzeiten an Eventtagen.">
+    <link rel="stylesheet" type="text/css" href="/typo3conf/ext/p2p/Resources/Public/assets_dist/css/styles.css?1566554732" media="all">
+    <meta property="og:title" content="Öffnungszeiten & Anreise " />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://www.heide-park.de/infos/oeffnungszeiten-anreise.html" />
+    <meta property="og:site_name" content="Heide Park Resort" />
+    <meta property="og:description" content="Seht auf einen Blick alle Öffnungszeiten des Heide Park Resorts: Innerhalb der Saison auch an Feiertagen geöffnet! Beachtet die Sonderzeiten an Eventtagen." />
+    <meta property="og:image" content="https://www.heide-park.de/typo3conf/ext/p2p/Resources/Public/assets_dist/img/hp-fb-logo.png" />
+    <link rel="author" href="https://plus.google.com/+heideparkresort/" />
+    <link rel="dns-prefetch" href="//www.heide-park.de">
+    <link rel="preconnect" href="//www.heide-park.de">
+    <link rel="preload prefetch" href="https://fonts.googleapis.com/css?family=Open+Sans:400,400i,300,600,700,800|Open+Sans+Condensed:300,700&subset=latin,latin-ext" as="style">
+    <link rel="preload prefetch" href="https://fonts.googleapis.com/css?family=Creepster" as="style">
+    <link rel="preload" href="//www.heide-park.de/typo3conf/ext/p2p/Resources/Public/assets_dist/img/logo.png" as="image">
+    <link rel="preload" href="//www.heide-park.de/typo3conf/ext/p2p/Resources/Public/assets_dist/img/toolbar.png" as="image">
+    <style>
+        @media only screen and (min-width: 786px) {
+            .page--halloween .page__inner {
+                margin-top: 77px;
+            }
+        }
+        
+        .page--halloween .toolbar--panelfixed {
+            display: none !important;
+        }
+    </style>
+    <title>Öffnungszeiten & Anreise &#124; Heide Park Resort</title>
+    <link href='https://fonts.googleapis.com/css?family=Open+Sans:400,400i,300,600,700,800|Open+Sans+Condensed:300,700&subset=latin,latin-ext' rel='stylesheet' type='text/css'>
+    <link href='https://fonts.googleapis.com/css?family=Creepster' rel='stylesheet' type='text/css'>
+    <script src="/typo3conf/ext/p2p/Resources/Public/assets_dist/js/vendor/modernizr/modernizr.js" type="text/javascript"></script>
+</head>
+
+<body>
+    <!-- Google Tag Manager -->
+    <noscript>
+        <iframe src="//www.googletagmanager.com/ns.html?id=GTM-JMBMMF" height="0" width="0" style="display:none;visibility:hidden"></iframe>
+    </noscript>
+    <script>
+        (function(w, d, s, l, i) {
+            w[l] = w[l] || [];
+            w[l].push({
+                'gtm.start': new Date().getTime(),
+                event: 'gtm.js'
+            });
+            var f = d.getElementsByTagName(s)[0],
+                j = d.createElement(s),
+                dl = l != 'dataLayer' ? '&l=' + l : '';
+            j.async = true;
+            j.src = '//www.googletagmanager.com/gtm.js?id=' + i + dl;
+            f.parentNode.insertBefore(j, f);
+        })(window, document, 'script', 'dataLayer', 'GTM-JMBMMF');
+    </script>
+    <!-- End Google Tag Manager -->
+    <div class="body-inner clearfix " onclick="void(0)">
+        <div class="page ">
+            <div class="newsticker-wrap newsticker-wrap--mobile js-mobile-ticker">
+                <div class="tickercontainer ">
+                    <div class="row">
+                        <div class="columns small-12">
+                            <div class="mask">
+                                <ul class="js-ticker newsticker">
+                                    <li>&bull;</li>
+                                    <li> <a href="/tickets/tages-tickets.html">Tageskassen ab 9 Uhr geöffnet || Unser Tipp: Tickets online buchen &amp; Anstehen an der Kasse vermeiden! </a> </li>
+                                </ul>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <header class="header" role="banner">
+                <div class="cookie-bar js-cookie-bar hidden">
+                    <div class="row">
+                        <div class="columns small-12 medium-10 large-8 end medium-centered">
+                            <a href="/infos/oeffnungszeiten-anreise.html?tx__%5Baction%5D=close&amp;tx__%5Bcontroller%5D=Standard&amp;cHash=2b6554456b40a281fc58b7d1bb076757" class="cookie-bar__close js-cookie-bar-close" aria-label="Cookie-Hinweis schließen"></a>
+                            <p class="bodytext">Wir verwenden Cookies, um Dir das beste Erlebnis auf unserer Website zu bieten und uns und Dritten die Möglichkeit zu geben, Anzeigen, die Du auf dieser und anderen Websites siehst, individuell anzupassen. Durch Fortsetzung Deines Besuchs stimmst Du&nbsp;<a href="/infos/cookies.html">der Verwendung von Cookies</a>&nbsp;zu.</p>
+                        </div>
+                    </div>
+                </div>
+                <div class="nomobile hide-for-small-only">
+                    <div class="toprow toprow--hasticker">
+                        <div class="newsticker-wrap">
+                            <div class="tickercontainer ">
+                                <div class="row">
+                                    <div class="columns small-12">
+                                        <div class="mask">
+                                            <ul class="js-ticker newsticker">
+                                                <li>&bull;</li>
+                                                <li> <a href="/tickets/tages-tickets.html"> Tageskassen ab 9 Uhr geöffnet || Unser Tipp: Tickets online buchen &amp; Anstehen an der Kasse vermeiden! </a> </li>
+                                            </ul>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="row">
+                            <div class="large-12 columns text-right">
+                                <form action="/infos/hilfefaq/suche.html" method="post" class="inline-form search-form clearfix">
+                                    <input class="search" type="text" name="tx_solr[q]" placeholder="Suchbegriff eingeben">
+                                    <input type="hidden" name="L" value="0">
+                                    <button type="submit" class="search-submit"> <span class="icon-search" aria-hidden="true"></span> </button>
+                                </form>
+                                <div class="dt-lang"> <span style="display:none"></span> </div>
+                            </div>
+                        </div>
+                    </div>
+                    <nav class="nav font-secondary">
+                        <div class="row">
+                            <div class="medium-2 columns">
+                                <a href="/" class=""> <img src="/typo3conf/ext/p2p/Resources/Public/assets_dist/img/logo.png" class="logo" alt="Heide Park Resort Logo" width="245" height="155" /> </a>
+                            </div>
+                            <div class="medium-10 columns">
+                                <ul class="nav-list mainlevel">
+                                    <li class=""> <a href="/tickets.html">Tickets</a>
+                                        <ul class="nav-list sublevel sublevel--lvlone">
+                                            <li class=""> <a href="/tickets/tages-tickets.html">Tages-Tickets</a> </li>
+                                            <li class=""> <a href="/tickets/saisonpaesse-jahreskarten.html">Saisonpässe &amp; Jahreskarten</a> </li>
+                                            <li class=""> <a href="/tickets/vip-pakete.html">VIP-Pakete</a> </li>
+                                            <li class=""> <a href="/tickets/extras.html">Extras</a> </li>
+                                        </ul>
+                                    </li>
+                                    <li class=""> <a href="/kurzurlaub.html">Kurzurlaub</a>
+                                        <ul class="nav-list sublevel sublevel--lvlone">
+                                            <li class=""> <a href="/kurzurlaub/abenteuerhotel.html">Abenteuerhotel</a>
+                                                <ul class="nav-list sublevel sublevel--lvltwo">
+                                                    <li class=""> <a href="/kurzurlaub/abenteuerhotel/willkommen.html"> Willkommen </a> </li>
+                                                    <li class=""> <a href="/kurzurlaub/abenteuerhotel/angebote-preise.html"> Angebote &amp; Preise </a> </li>
+                                                    <li class=""> <a href="/kurzurlaub/abenteuerhotel/zimmer.html"> Zimmer </a> </li>
+                                                    <li class=""> <a href="/kurzurlaub/abenteuerhotel/spassbad-sauna.html"> Spaßbad &amp; Sauna </a> </li>
+                                                    <li class=""> <a href="/kurzurlaub/abenteuerhotel/kulinarisches.html"> Kulinarisches </a> </li>
+                                                    <li class=""> <a href="/kurzurlaub/abenteuerhotel/highlights-fuer-kids.html"> Highlights für Kids </a> </li>
+                                                </ul>
+                                            </li>
+                                            <li class=""> <a href="/kurzurlaub/holiday-camp.html">Holiday Camp</a>
+                                                <ul class="nav-list sublevel sublevel--lvltwo">
+                                                    <li class=""> <a href="/kurzurlaub/holiday-camp/willkommen.html"> Willkommen </a> </li>
+                                                    <li class=""> <a href="/kurzurlaub/holiday-camp/angebote-preise.html"> Angebote &amp; Preise </a> </li>
+                                                    <li class=""> <a href="/kurzurlaub/holiday-camp/unterkuenfte.html"> Unterkünfte </a> </li>
+                                                    <li class=""> <a href="/kurzurlaub/holiday-camp/inklusivleistungen.html"> Inklusivleistungen </a> </li>
+                                                </ul>
+                                            </li>
+                                        </ul>
+                                    </li>
+                                    <li class=""> <a href="/attraktionen.html">Attraktionen</a>
+                                        <ul class="nav-list sublevel sublevel--lvlone">
+                                            <li class=""> <a href="/attraktionen/attraktionsfinder.html">Attraktionsfinder</a> </li>
+                                            <li class=""> <a href="/attraktionen/colossos-2019.html">Colossos 2019</a> </li>
+                                            <li class=""> <a href="/attraktionen/events.html">Events</a> </li>
+                                        </ul>
+                                    </li>
+                                    <li class="active"> <a href="/infos.html">Infos</a>
+                                        <ul class="nav-list sublevel sublevel--lvlone">
+                                            <li class="active"> <a href="/infos/oeffnungszeiten-anreise.html">Öffnungszeiten &amp; Anreise</a> </li>
+                                            <li class=""> <a href="/infos/schoenwetter-garantie.html">Schönwetter-Garantie</a> </li>
+                                            <li class=""> <a href="/infos/top-tipps.html">Top Tipps</a> </li>
+                                            <li class=""> <a href="/infos/service.html">Service</a> </li>
+                                            <li class=""> <a href="/infos/hilfefaq.html">Hilfe/FAQ</a> </li>
+                                            <li class=""> <a href="/infos/kontakt.html">Kontakt</a> </li>
+                                        </ul>
+                                    </li>
+                                    <li class=""> <a href="/gruppen-schulen.html">Gruppen &amp; Schulen</a>
+                                        <ul class="nav-list sublevel sublevel--lvlone">
+                                            <li class=""> <a href="/gruppen-schulen/gruppenpreise.html">Gruppenpreise</a> </li>
+                                            <li class=""> <a href="/gruppen-schulen/paedagogische-angebote.html">Pädagogische Angebote</a> </li>
+                                            <li class=""> <a href="/gruppen-schulen/uebernachten.html">Übernachten</a> </li>
+                                        </ul>
+                                    </li>
+                                    <li class=""> <a href="/tagungen-feiern.html">Firmen</a>
+                                        <ul class="nav-list sublevel sublevel--lvlone">
+                                            <li class=""> <a href="/tagungen-feiern/angebote-preise.html">Angebote &amp; Preise</a> </li>
+                                            <li class=""> <a href="/tagungen-feiern/raeume-locations.html">Räume &amp; Locations</a> </li>
+                                            <li class=""> <a href="/tagungen-feiern/extras.html">Extras</a> </li>
+                                            <li class=""> <a href="/tagungen-feiern/kontaktanfrage.html">Kontaktanfrage</a> </li>
+                                        </ul>
+                                    </li>
+                                    <li class=""> <a href="/jobs.html">Jobs</a>
+                                        <ul class="nav-list sublevel sublevel--lvlone">
+                                            <li class=""> <a href="/jobs/wir-bieten-dir.html">Wir bieten Dir . . .</a> </li>
+                                            <li class=""> <a href="/jobs/saisonale-stellenangebote.html">Saisonale Stellenangebote</a> </li>
+                                            <li class=""> <a href="/jobs/festanstellungen.html">Festanstellungen</a> </li>
+                                            <li class=""> <a href="/jobs/praktikum.html">Praktikum</a> </li>
+                                            <li class=""> <a href="/jobs/bewerbungsformular.html">Bewerbungsformular</a> </li>
+                                        </ul>
+                                    </li>
+                                </ul>
+                                <div class="loup js-loupreveal"></div>
+                            </div>
+                        </div>
+                    </nav>
+                    <!--end .nav-->
+                    <div class="nav__secondary">
+                        <div class="row">
+                            <div class="large-16 columns"></div>
+                        </div>
+                    </div>
+                    <div class="nav__tertiary">
+                        <div class="row">
+                            <div class="large-16 columns"></div>
+                        </div>
+                    </div>
+                </div>
+                <!-- .nomobile hide-for-small-only -->
+                <a href="/" class="logo--small"> <img src="/typo3conf/ext/p2p/Resources/Public/assets_dist/img/logo.png" class="logo" alt="Heide Park Resort Logo" width="245" height="155" /> </a>
+                <div class="js-mobile mobile-nav show-for-small-only js-mobile--hasticker">
+                    <div class="menuhead"></div>
+                    <div class="menu-icon"></div>
+                    <!--<a href="#search-form" class="nav-toggle nav-toggle-search icon-search"> <span class="is-vishidden">Search</span> </a> <a href="#nav" class="nav-toggle nav-toggle-menu icon-menu"> <span class="is-vishidden">Menu</span> </a>-->
+                    <div class="loup-icon"></div>
+                    <div class="toprow">
+                        <div class="row">
+                            <div class="large-12 columns">
+                                <form action="/infos/hilfefaq/suche.html" method="post" class="inline-form search-form clearfix">
+                                    <input class="search" type="text" name="tx_solr[q]" placeholder="Suchbegriff eingeben">
+                                    <input type="hidden" name="L" value="0">
+                                    <button type="submit" class="search-submit"> <span class="icon-search" aria-hidden="true"></span> </button>
+                                </form>
+                            </div>
+                        </div>
+                    </div>
+                    <nav class="nav font-secondary mobile--first">
+                        <ul class="nav-list">
+                            <li> <a href="/tickets.html">Tickets</a>
+                                <div> <a class="mm-title mm-btn mm-prev" href="#mm-0">Zurück</a> </div>
+                                <ul class="nav-list">
+                                    <li class=""> <a href="/tickets/tages-tickets.html">Tages-Tickets</a> </li>
+                                    <li class=""> <a href="/tickets/saisonpaesse-jahreskarten.html">Saisonpässe &amp; Jahreskarten</a> </li>
+                                    <li class=""> <a href="/tickets/vip-pakete.html">VIP-Pakete</a> </li>
+                                    <li class=""> <a href="/tickets/extras.html">Extras</a> </li>
+                                </ul>
+                            </li>
+                            <li> <a href="/kurzurlaub.html">Kurzurlaub</a>
+                                <div> <a class="mm-title mm-btn mm-prev" href="#mm-0">Zurück</a> </div>
+                                <ul class="nav-list">
+                                    <li class=""> <a href="/kurzurlaub/abenteuerhotel.html">Abenteuerhotel</a>
+                                        <div> <a class="mm-title mm-btn mm-prev" href="#mm-1">Zurück</a> </div>
+                                        <ul class="nav-list">
+                                            <li class=""> <a href="/kurzurlaub/abenteuerhotel/willkommen.html">Willkommen </a> </li>
+                                            <li class=""> <a href="/kurzurlaub/abenteuerhotel/angebote-preise.html">Angebote &amp; Preise </a> </li>
+                                            <li class=""> <a href="/kurzurlaub/abenteuerhotel/zimmer.html">Zimmer </a> </li>
+                                            <li class=""> <a href="/kurzurlaub/abenteuerhotel/spassbad-sauna.html">Spaßbad &amp; Sauna </a> </li>
+                                            <li class=""> <a href="/kurzurlaub/abenteuerhotel/kulinarisches.html">Kulinarisches </a> </li>
+                                            <li class=""> <a href="/kurzurlaub/abenteuerhotel/highlights-fuer-kids.html">Highlights für Kids </a> </li>
+                                        </ul>
+                                    </li>
+                                    <li class=""> <a href="/kurzurlaub/holiday-camp.html">Holiday Camp</a>
+                                        <div> <a class="mm-title mm-btn mm-prev" href="#mm-1">Zurück</a> </div>
+                                        <ul class="nav-list">
+                                            <li class=""> <a href="/kurzurlaub/holiday-camp/willkommen.html">Willkommen </a> </li>
+                                            <li class=""> <a href="/kurzurlaub/holiday-camp/angebote-preise.html">Angebote &amp; Preise </a> </li>
+                                            <li class=""> <a href="/kurzurlaub/holiday-camp/unterkuenfte.html">Unterkünfte </a> </li>
+                                            <li class=""> <a href="/kurzurlaub/holiday-camp/inklusivleistungen.html">Inklusivleistungen </a> </li>
+                                        </ul>
+                                    </li>
+                                </ul>
+                            </li>
+                            <li> <a href="/attraktionen.html">Attraktionen</a>
+                                <div> <a class="mm-title mm-btn mm-prev" href="#mm-0">Zurück</a> </div>
+                                <ul class="nav-list">
+                                    <li class=""> <a href="/attraktionen/attraktionsfinder.html">Attraktionsfinder</a> </li>
+                                    <li class=""> <a href="/attraktionen/colossos-2019.html">Colossos 2019</a> </li>
+                                    <li class=""> <a href="/attraktionen/events.html">Events</a> </li>
+                                </ul>
+                            </li>
+                            <li> <a href="/infos.html">Infos</a>
+                                <div> <a class="mm-title mm-btn mm-prev" href="#mm-0">Zurück</a> </div>
+                                <ul class="nav-list">
+                                    <li class="Selected"> <a href="/infos/oeffnungszeiten-anreise.html">Öffnungszeiten &amp; Anreise</a> </li>
+                                    <li class=""> <a href="/infos/schoenwetter-garantie.html">Schönwetter-Garantie</a> </li>
+                                    <li class=""> <a href="/infos/top-tipps.html">Top Tipps</a> </li>
+                                    <li class=""> <a href="/infos/service.html">Service</a> </li>
+                                    <li class=""> <a href="/infos/hilfefaq.html">Hilfe/FAQ</a> </li>
+                                    <li class=""> <a href="/infos/kontakt.html">Kontakt</a> </li>
+                                </ul>
+                            </li>
+                            <li> <a href="/gruppen-schulen.html">Gruppen &amp; Schulen</a>
+                                <div> <a class="mm-title mm-btn mm-prev" href="#mm-0">Zurück</a> </div>
+                                <ul class="nav-list">
+                                    <li class=""> <a href="/gruppen-schulen/gruppenpreise.html">Gruppenpreise</a> </li>
+                                    <li class=""> <a href="/gruppen-schulen/paedagogische-angebote.html">Pädagogische Angebote</a> </li>
+                                    <li class=""> <a href="/gruppen-schulen/uebernachten.html">Übernachten</a> </li>
+                                </ul>
+                            </li>
+                            <li> <a href="/tagungen-feiern.html">Firmen</a>
+                                <div> <a class="mm-title mm-btn mm-prev" href="#mm-0">Zurück</a> </div>
+                                <ul class="nav-list">
+                                    <li class=""> <a href="/tagungen-feiern/angebote-preise.html">Angebote &amp; Preise</a> </li>
+                                    <li class=""> <a href="/tagungen-feiern/raeume-locations.html">Räume &amp; Locations</a> </li>
+                                    <li class=""> <a href="/tagungen-feiern/extras.html">Extras</a> </li>
+                                    <li class=""> <a href="/tagungen-feiern/kontaktanfrage.html">Kontaktanfrage</a> </li>
+                                </ul>
+                            </li>
+                            <li> <a href="/jobs.html">Jobs</a>
+                                <div> <a class="mm-title mm-btn mm-prev" href="#mm-0">Zurück</a> </div>
+                                <ul class="nav-list">
+                                    <li class=""> <a href="/jobs/wir-bieten-dir.html">Wir bieten Dir . . .</a> </li>
+                                    <li class=""> <a href="/jobs/saisonale-stellenangebote.html">Saisonale Stellenangebote</a> </li>
+                                    <li class=""> <a href="/jobs/festanstellungen.html">Festanstellungen</a> </li>
+                                    <li class=""> <a href="/jobs/praktikum.html">Praktikum</a> </li>
+                                    <li class=""> <a href="/jobs/bewerbungsformular.html">Bewerbungsformular</a> </li>
+                                </ul>
+                            </li>
+                        </ul>
+                    </nav>
+                    <!--end .nav mobile first-->
+                    <div class="toolbar__bar hide-for-large-up">
+                        <div class="toolbar__timelist clearfix">
+                            <ul class="toolbar__submenu">
+                                <li class="toolbar__liststyle toolbar__timelist">Öffnungszeiten</li>
+                                <li class="toolbar__liststyle toolbar__timelist"> Heute
+                                    <br> <span class="toolbar__timer"> Park: 10 - 19 Uhr <br> Attraktionen: 10 - 18 Uhr </span> </li>
+                                <li class="toolbar__liststyle toolbar__timelist"> Morgen
+                                    <br> <span class="toolbar__timer"> Park: 10 - 19 Uhr <br> Attraktionen: 10 - 18 Uhr </span> </li>
+                            </ul>
+                            <div class="toolbar__submenu toolbar__plan">
+                                <a class="toolbar__footerplan" href="/fileadmin/content/info/HP_Parkplan_2019.jpg"></a> <a href="#" class="toolbar__planlink"> Parkplan </a> </div>
+                            <div class="toolbar__submenu"> <span style="display:none"></span> </div>
+                        </div>
+                    </div>
+                </div>
+            </header>
+            <div class="page__inner page__inner--hasticker" role="main">
+                <!--TYPO3SEARCH_begin-->
+                <div class="img-svg-mask">
+                    <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="100%" preserveAspectRatio="xMinYMin" viewBox="0 0 1600 582">
+                        <defs>
+                            <mask id="svgmask2">
+                                <image width="100%" height="100%" xlink:href="/typo3conf/ext/p2p/Resources/Public/assets_dist/img/mask.png" /> </mask>
+                        </defs>
+                        <switch>
+                            <foreignObject mask="url(#svgmask2)" x="0" y="0" width="1600" height="582" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                                <g>
+                                    <picture>
+                                        <source media="(min-width: 1280px)" srcset="/fileadmin/_processed_/0/4/csm_180209_3200x1164_AnfahrtOeffnungszeiten_b30e366050.jpg 2x, /fileadmin/_processed_/0/4/csm_180209_3200x1164_AnfahrtOeffnungszeiten_b39794c4e8.jpg 1x">
+                                        <source media="(min-width: 788px)" srcset="/fileadmin/_processed_/0/4/csm_180209_3200x1164_AnfahrtOeffnungszeiten_51763f11d6.jpg 2x, /fileadmin/_processed_/0/4/csm_180209_3200x1164_AnfahrtOeffnungszeiten_7a05f193a2.jpg 1x">
+                                        <source media="(min-width: 376px)" srcset="/fileadmin/_processed_/0/4/csm_180209_3200x1164_AnfahrtOeffnungszeiten_b87ff29e59.jpg 2x,/fileadmin/_processed_/0/4/csm_180209_3200x1164_AnfahrtOeffnungszeiten_eaaec85e92.jpg 1x">
+                                        <source media="(min-width: 200px)" srcset="/fileadmin/_processed_/0/4/csm_180209_3200x1164_AnfahrtOeffnungszeiten_c2e72fd88d.jpg 2x, /fileadmin/_processed_/0/4/csm_180209_3200x1164_AnfahrtOeffnungszeiten_ddafe88580.jpg 1x">
+                                        <image mask="url(#svgmask2)" src="/fileadmin/_processed_/0/4/csm_180209_3200x1164_AnfahrtOeffnungszeiten_c2e72fd88d.jpg" alt="" style="width:auto;" /> </picture>
+                                </g>
+                            </foreignObject>
+                            <image mask="url(#svgmask2)" width="100%" height="100%" xlink:href="/fileadmin/_processed_/0/4/csm_180209_3200x1164_AnfahrtOeffnungszeiten_b30e366050.jpg" /> </switch>
+                    </svg>
+                </div>
+                <div class="row">
+                    <div class="columns small-12">
+                        <div class="img-header center">
+                            <picture>
+                                <source srcset="/fileadmin/_processed_/c/9/csm_180215_Oeffnungszeiten_Anreise_f8490bff03.png 2x, /fileadmin/_processed_/c/9/csm_180215_Oeffnungszeiten_Anreise_096bd62796.png 1x"> <img src="/fileadmin/_processed_/c/9/csm_180215_Oeffnungszeiten_Anreise_096bd62796.png" data-src="/fileadmin/_processed_/c/9/csm_180215_Oeffnungszeiten_Anreise_096bd62796.png" width="898" height="180" alt="" /> </picture>
+                            <h1 class="img-header__headline font-tertiary"> <span class="img-header__hiddenheader">Öffnungszeiten &amp; Anreise</span> Saison 2019: 06. April bis 03. November* </h1>
+                            <div class="row">
+                                <div class="columns large-10 large-centered">
+                                    <div class="img-header__text"> </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="clearfix text-center cal-slot-container">
+                    <div class="cal-slot">
+                        <div class="cal-slot__color cal-slot__color--1"></div>
+                        <div class="cal-slot__text"> Park: 10-18 Uhr
+                            <br> Attraktionen: 10-17 Uhr </div>
+                    </div>
+                    <div class="cal-slot">
+                        <div class="cal-slot__color cal-slot__color--2"></div>
+                        <div class="cal-slot__text"> Park: 10-19 Uhr
+                            <br> Attraktionen: 10-18 Uhr </div>
+                    </div>
+                    <div class="cal-slot">
+                        <div class="cal-slot__color cal-slot__color--3"></div>
+                        <div class="cal-slot__text"> Park: 10-21 Uhr
+                            <br> Attraktionen: 10-20 Uhr </div>
+                    </div>
+                    <div class="cal-slot">
+                        <div class="cal-slot__color cal-slot__color--4"></div>
+                        <div class="cal-slot__text"> Park: 10-22 Uhr
+                            <br> Attraktionen: 10-21 Uhr </div>
+                    </div>
+                    <div class="cal-slot">
+                        <div class="cal-slot__color cal-slot__color--0"></div>
+                        <div class="cal-slot__text"> Geschlossen </div>
+                    </div>
+                </div>
+                <div class="row collapse medium-uncollapse">
+                    <div class="columns">
+                        <div class="cal-arrows">
+                            <button class="js-cal-prev cal-arrow cal-arrow--prev" aria-label="Vorherrige" title="Vorherrige"></button>
+                            <button class="js-cal-next cal-arrow cal-arrow--next" aria-label="Nächste" title="Nächste"></button>
+                        </div>
+                        <div class="js-cal-slider slick-slider calendar-slider">
+                            <div class="slider-item slick-slide">
+                                <div class="cal clearfix">
+                                    <div class="cal__header">
+                                        <div class="cal__month">August 2019</div>
+                                        <div class="cal__header-cell">Mo</div>
+                                        <div class="cal__header-cell">Di</div>
+                                        <div class="cal__header-cell">Mi</div>
+                                        <div class="cal__header-cell">Do</div>
+                                        <div class="cal__header-cell">Fr</div>
+                                        <div class="cal__header-cell">Sa</div>
+                                        <div class="cal__header-cell">So</div>
+                                    </div>
+                                    <div class="cal__cell-row">
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                    </div>
+                                    <div class="cal__cell-row">
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                    </div>
+                                    <div class="cal__cell-row">
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                    </div>
+                                    <div class="cal__cell-row">
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot-2 js-cal-day">
+                                            <div class="cal__daynumber">25</div>
+                                            <div class="js-cal-day-content" style="display: none">
+                                                <div class="day-info__header">Sonntag, 25.08.2019</div> <span class="day-info__label day-info__label--hours">Park:</span> <span class="day-info__hours">10 - 19 Uhr</span>
+                                                <br> <span class="day-info__label day-info__label--hours">Attraktionen:</span> <span class="day-info__hours">10 - 18 Uhr</span>
+                                                <br> </div>
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                    </div>
+                                    <div class="cal__cell-row">
+                                        <div class="cal__cell cal__cell--slot-2 cal__cell--tag cal__cell--tag-vip-friends-special js-cal-day">
+                                            <div class="cal__daynumber">26</div>
+                                            <div class="js-cal-day-content" style="display: none">
+                                                <div class="day-info__header">Montag, 26.08.2019</div> <span class="day-info__label day-info__label--hours">Park:</span> <span class="day-info__hours">10 - 19 Uhr</span>
+                                                <br> <span class="day-info__label day-info__label--hours">Attraktionen:</span> <span class="day-info__hours">10 - 18 Uhr</span>
+                                                <br>
+                                                <div class="day-info__label"> <a href="/tickets/tages-tickets.html"> VIP Saisonpass: Freunde-Special </a> </div>
+                                            </div>
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot-2 js-cal-day">
+                                            <div class="cal__daynumber">27</div>
+                                            <div class="js-cal-day-content" style="display: none">
+                                                <div class="day-info__header">Dienstag, 27.08.2019</div> <span class="day-info__label day-info__label--hours">Park:</span> <span class="day-info__hours">10 - 19 Uhr</span>
+                                                <br> <span class="day-info__label day-info__label--hours">Attraktionen:</span> <span class="day-info__hours">10 - 18 Uhr</span>
+                                                <br> </div>
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot-1 js-cal-day">
+                                            <div class="cal__daynumber">28</div>
+                                            <div class="js-cal-day-content" style="display: none">
+                                                <div class="day-info__header">Mittwoch, 28.08.2019</div> <span class="day-info__label day-info__label--hours">Park:</span> <span class="day-info__hours">10 - 18 Uhr</span>
+                                                <br> <span class="day-info__label day-info__label--hours">Attraktionen:</span> <span class="day-info__hours">10 - 17 Uhr</span>
+                                                <br> </div>
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot-1 js-cal-day">
+                                            <div class="cal__daynumber">29</div>
+                                            <div class="js-cal-day-content" style="display: none">
+                                                <div class="day-info__header">Donnerstag, 29.08.2019</div> <span class="day-info__label day-info__label--hours">Park:</span> <span class="day-info__hours">10 - 18 Uhr</span>
+                                                <br> <span class="day-info__label day-info__label--hours">Attraktionen:</span> <span class="day-info__hours">10 - 17 Uhr</span>
+                                                <br> </div>
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot-1 cal__cell--tag cal__cell--tag-vip-friends-special js-cal-day">
+                                            <div class="cal__daynumber">30</div>
+                                            <div class="js-cal-day-content" style="display: none">
+                                                <div class="day-info__header">Freitag, 30.08.2019</div> <span class="day-info__label day-info__label--hours">Park:</span> <span class="day-info__hours">10 - 18 Uhr</span>
+                                                <br> <span class="day-info__label day-info__label--hours">Attraktionen:</span> <span class="day-info__hours">10 - 17 Uhr</span>
+                                                <br>
+                                                <div class="day-info__label"> <a href="/tickets/tages-tickets.html"> VIP Saisonpass: Freunde-Special </a> </div>
+                                            </div>
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot-2 cal__cell--tag cal__cell--tag-zombie-escape js-cal-day">
+                                            <div class="cal__daynumber">31</div>
+                                            <div class="js-cal-day-content" style="display: none">
+                                                <div class="day-info__header">Samstag, 31.08.2019</div> <span class="day-info__label day-info__label--hours">Park:</span> <span class="day-info__hours">10 - 19 Uhr</span>
+                                                <br> <span class="day-info__label day-info__label--hours">Attraktionen:</span> <span class="day-info__hours">10 - 18 Uhr</span>
+                                                <br>
+                                                <div class="day-info__label"> <a href="/attraktionen/events.html"> Zombie Escape </a> </div>
+                                            </div>
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="slider-item slick-slide">
+                                <div class="cal clearfix">
+                                    <div class="cal__header">
+                                        <div class="cal__month">September 2019</div>
+                                        <div class="cal__header-cell">Mo</div>
+                                        <div class="cal__header-cell">Di</div>
+                                        <div class="cal__header-cell">Mi</div>
+                                        <div class="cal__header-cell">Do</div>
+                                        <div class="cal__header-cell">Fr</div>
+                                        <div class="cal__header-cell">Sa</div>
+                                        <div class="cal__header-cell">So</div>
+                                    </div>
+                                    <div class="cal__cell-row">
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot-2 js-cal-day">
+                                            <div class="cal__daynumber">1</div>
+                                            <div class="js-cal-day-content" style="display: none">
+                                                <div class="day-info__header">Sonntag, 01.09.2019</div> <span class="day-info__label day-info__label--hours">Park:</span> <span class="day-info__hours">10 - 19 Uhr</span>
+                                                <br> <span class="day-info__label day-info__label--hours">Attraktionen:</span> <span class="day-info__hours">10 - 18 Uhr</span>
+                                                <br> </div>
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                    </div>
+                                    <div class="cal__cell-row">
+                                        <div class="cal__cell cal__cell--slot-1 cal__cell--tag cal__cell--tag-vip-friends-special js-cal-day">
+                                            <div class="cal__daynumber">2</div>
+                                            <div class="js-cal-day-content" style="display: none">
+                                                <div class="day-info__header">Montag, 02.09.2019</div> <span class="day-info__label day-info__label--hours">Park:</span> <span class="day-info__hours">10 - 18 Uhr</span>
+                                                <br> <span class="day-info__label day-info__label--hours">Attraktionen:</span> <span class="day-info__hours">10 - 17 Uhr</span>
+                                                <br>
+                                                <div class="day-info__label"> <a href="/tickets/tages-tickets.html"> VIP Saisonpass: Freunde-Special </a> </div>
+                                            </div>
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot-1 js-cal-day">
+                                            <div class="cal__daynumber">3</div>
+                                            <div class="js-cal-day-content" style="display: none">
+                                                <div class="day-info__header">Dienstag, 03.09.2019</div> <span class="day-info__label day-info__label--hours">Park:</span> <span class="day-info__hours">10 - 18 Uhr</span>
+                                                <br> <span class="day-info__label day-info__label--hours">Attraktionen:</span> <span class="day-info__hours">10 - 17 Uhr</span>
+                                                <br> </div>
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot-1 js-cal-day">
+                                            <div class="cal__daynumber">4</div>
+                                            <div class="js-cal-day-content" style="display: none">
+                                                <div class="day-info__header">Mittwoch, 04.09.2019</div> <span class="day-info__label day-info__label--hours">Park:</span> <span class="day-info__hours">10 - 18 Uhr</span>
+                                                <br> <span class="day-info__label day-info__label--hours">Attraktionen:</span> <span class="day-info__hours">10 - 17 Uhr</span>
+                                                <br> </div>
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot-1 js-cal-day">
+                                            <div class="cal__daynumber">5</div>
+                                            <div class="js-cal-day-content" style="display: none">
+                                                <div class="day-info__header">Donnerstag, 05.09.2019</div> <span class="day-info__label day-info__label--hours">Park:</span> <span class="day-info__hours">10 - 18 Uhr</span>
+                                                <br> <span class="day-info__label day-info__label--hours">Attraktionen:</span> <span class="day-info__hours">10 - 17 Uhr</span>
+                                                <br> </div>
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot-0 js-cal-day">
+                                            <div class="cal__daynumber">6</div>
+                                            <div class="js-cal-day-content" style="display: none">
+                                                <div class="day-info__header">Freitag, 06.09.2019</div>
+                                                <div class="day-info__label"> Park: geschlossen </div>
+                                                <div class="day-info__label"> Attraktionen: geschlossen </div>
+                                            </div>
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot-2 cal__cell--tag cal__cell--tag-zombie-escape js-cal-day">
+                                            <div class="cal__daynumber">7</div>
+                                            <div class="js-cal-day-content" style="display: none">
+                                                <div class="day-info__header">Samstag, 07.09.2019</div> <span class="day-info__label day-info__label--hours">Park:</span> <span class="day-info__hours">10 - 19 Uhr</span>
+                                                <br> <span class="day-info__label day-info__label--hours">Attraktionen:</span> <span class="day-info__hours">10 - 18 Uhr</span>
+                                                <br>
+                                                <div class="day-info__label"> <a href="/attraktionen/events.html"> Zombie Escape </a> </div>
+                                            </div>
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot-2 js-cal-day">
+                                            <div class="cal__daynumber">8</div>
+                                            <div class="js-cal-day-content" style="display: none">
+                                                <div class="day-info__header">Sonntag, 08.09.2019</div> <span class="day-info__label day-info__label--hours">Park:</span> <span class="day-info__hours">10 - 19 Uhr</span>
+                                                <br> <span class="day-info__label day-info__label--hours">Attraktionen:</span> <span class="day-info__hours">10 - 18 Uhr</span>
+                                                <br> </div>
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                    </div>
+                                    <div class="cal__cell-row">
+                                        <div class="cal__cell cal__cell--slot-1 cal__cell--tag cal__cell--tag-vip-friends-special js-cal-day">
+                                            <div class="cal__daynumber">9</div>
+                                            <div class="js-cal-day-content" style="display: none">
+                                                <div class="day-info__header">Montag, 09.09.2019</div> <span class="day-info__label day-info__label--hours">Park:</span> <span class="day-info__hours">10 - 18 Uhr</span>
+                                                <br> <span class="day-info__label day-info__label--hours">Attraktionen:</span> <span class="day-info__hours">10 - 17 Uhr</span>
+                                                <br>
+                                                <div class="day-info__label"> <a href="/tickets/tages-tickets.html"> VIP Saisonpass: Freunde-Special </a> </div>
+                                            </div>
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot-1 js-cal-day">
+                                            <div class="cal__daynumber">10</div>
+                                            <div class="js-cal-day-content" style="display: none">
+                                                <div class="day-info__header">Dienstag, 10.09.2019</div> <span class="day-info__label day-info__label--hours">Park:</span> <span class="day-info__hours">10 - 18 Uhr</span>
+                                                <br> <span class="day-info__label day-info__label--hours">Attraktionen:</span> <span class="day-info__hours">10 - 17 Uhr</span>
+                                                <br> </div>
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot-1 js-cal-day">
+                                            <div class="cal__daynumber">11</div>
+                                            <div class="js-cal-day-content" style="display: none">
+                                                <div class="day-info__header">Mittwoch, 11.09.2019</div> <span class="day-info__label day-info__label--hours">Park:</span> <span class="day-info__hours">10 - 18 Uhr</span>
+                                                <br> <span class="day-info__label day-info__label--hours">Attraktionen:</span> <span class="day-info__hours">10 - 17 Uhr</span>
+                                                <br> </div>
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot-1 js-cal-day">
+                                            <div class="cal__daynumber">12</div>
+                                            <div class="js-cal-day-content" style="display: none">
+                                                <div class="day-info__header">Donnerstag, 12.09.2019</div> <span class="day-info__label day-info__label--hours">Park:</span> <span class="day-info__hours">10 - 18 Uhr</span>
+                                                <br> <span class="day-info__label day-info__label--hours">Attraktionen:</span> <span class="day-info__hours">10 - 17 Uhr</span>
+                                                <br> </div>
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot-0 js-cal-day">
+                                            <div class="cal__daynumber">13</div>
+                                            <div class="js-cal-day-content" style="display: none">
+                                                <div class="day-info__header">Freitag, 13.09.2019</div>
+                                                <div class="day-info__label"> Park: geschlossen </div>
+                                                <div class="day-info__label"> Attraktionen: geschlossen </div>
+                                            </div>
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot-2 js-cal-day">
+                                            <div class="cal__daynumber">14</div>
+                                            <div class="js-cal-day-content" style="display: none">
+                                                <div class="day-info__header">Samstag, 14.09.2019</div> <span class="day-info__label day-info__label--hours">Park:</span> <span class="day-info__hours">10 - 19 Uhr</span>
+                                                <br> <span class="day-info__label day-info__label--hours">Attraktionen:</span> <span class="day-info__hours">10 - 18 Uhr</span>
+                                                <br> </div>
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot-2 js-cal-day">
+                                            <div class="cal__daynumber">15</div>
+                                            <div class="js-cal-day-content" style="display: none">
+                                                <div class="day-info__header">Sonntag, 15.09.2019</div> <span class="day-info__label day-info__label--hours">Park:</span> <span class="day-info__hours">10 - 19 Uhr</span>
+                                                <br> <span class="day-info__label day-info__label--hours">Attraktionen:</span> <span class="day-info__hours">10 - 18 Uhr</span>
+                                                <br> </div>
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                    </div>
+                                    <div class="cal__cell-row">
+                                        <div class="cal__cell cal__cell--slot-1 cal__cell--tag cal__cell--tag-vip-friends-special js-cal-day">
+                                            <div class="cal__daynumber">16</div>
+                                            <div class="js-cal-day-content" style="display: none">
+                                                <div class="day-info__header">Montag, 16.09.2019</div> <span class="day-info__label day-info__label--hours">Park:</span> <span class="day-info__hours">10 - 18 Uhr</span>
+                                                <br> <span class="day-info__label day-info__label--hours">Attraktionen:</span> <span class="day-info__hours">10 - 17 Uhr</span>
+                                                <br>
+                                                <div class="day-info__label"> <a href="/tickets/tages-tickets.html"> VIP Saisonpass: Freunde-Special </a> </div>
+                                            </div>
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot-1 js-cal-day">
+                                            <div class="cal__daynumber">17</div>
+                                            <div class="js-cal-day-content" style="display: none">
+                                                <div class="day-info__header">Dienstag, 17.09.2019</div> <span class="day-info__label day-info__label--hours">Park:</span> <span class="day-info__hours">10 - 18 Uhr</span>
+                                                <br> <span class="day-info__label day-info__label--hours">Attraktionen:</span> <span class="day-info__hours">10 - 17 Uhr</span>
+                                                <br> </div>
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot-1 js-cal-day">
+                                            <div class="cal__daynumber">18</div>
+                                            <div class="js-cal-day-content" style="display: none">
+                                                <div class="day-info__header">Mittwoch, 18.09.2019</div> <span class="day-info__label day-info__label--hours">Park:</span> <span class="day-info__hours">10 - 18 Uhr</span>
+                                                <br> <span class="day-info__label day-info__label--hours">Attraktionen:</span> <span class="day-info__hours">10 - 17 Uhr</span>
+                                                <br> </div>
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot-1 js-cal-day">
+                                            <div class="cal__daynumber">19</div>
+                                            <div class="js-cal-day-content" style="display: none">
+                                                <div class="day-info__header">Donnerstag, 19.09.2019</div> <span class="day-info__label day-info__label--hours">Park:</span> <span class="day-info__hours">10 - 18 Uhr</span>
+                                                <br> <span class="day-info__label day-info__label--hours">Attraktionen:</span> <span class="day-info__hours">10 - 17 Uhr</span>
+                                                <br> </div>
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot-0 js-cal-day">
+                                            <div class="cal__daynumber">20</div>
+                                            <div class="js-cal-day-content" style="display: none">
+                                                <div class="day-info__header">Freitag, 20.09.2019</div>
+                                                <div class="day-info__label"> Park: geschlossen </div>
+                                                <div class="day-info__label"> Attraktionen: geschlossen </div>
+                                            </div>
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot-2 js-cal-day">
+                                            <div class="cal__daynumber">21</div>
+                                            <div class="js-cal-day-content" style="display: none">
+                                                <div class="day-info__header">Samstag, 21.09.2019</div> <span class="day-info__label day-info__label--hours">Park:</span> <span class="day-info__hours">10 - 19 Uhr</span>
+                                                <br> <span class="day-info__label day-info__label--hours">Attraktionen:</span> <span class="day-info__hours">10 - 18 Uhr</span>
+                                                <br> </div>
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot-2 js-cal-day">
+                                            <div class="cal__daynumber">22</div>
+                                            <div class="js-cal-day-content" style="display: none">
+                                                <div class="day-info__header">Sonntag, 22.09.2019</div> <span class="day-info__label day-info__label--hours">Park:</span> <span class="day-info__hours">10 - 19 Uhr</span>
+                                                <br> <span class="day-info__label day-info__label--hours">Attraktionen:</span> <span class="day-info__hours">10 - 18 Uhr</span>
+                                                <br> </div>
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                    </div>
+                                    <div class="cal__cell-row">
+                                        <div class="cal__cell cal__cell--slot-1 cal__cell--tag cal__cell--tag-vip-friends-special js-cal-day">
+                                            <div class="cal__daynumber">23</div>
+                                            <div class="js-cal-day-content" style="display: none">
+                                                <div class="day-info__header">Montag, 23.09.2019</div> <span class="day-info__label day-info__label--hours">Park:</span> <span class="day-info__hours">10 - 18 Uhr</span>
+                                                <br> <span class="day-info__label day-info__label--hours">Attraktionen:</span> <span class="day-info__hours">10 - 17 Uhr</span>
+                                                <br>
+                                                <div class="day-info__label"> <a href="/tickets/tages-tickets.html"> VIP Saisonpass: Freunde-Special </a> </div>
+                                            </div>
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot-1 js-cal-day">
+                                            <div class="cal__daynumber">24</div>
+                                            <div class="js-cal-day-content" style="display: none">
+                                                <div class="day-info__header">Dienstag, 24.09.2019</div> <span class="day-info__label day-info__label--hours">Park:</span> <span class="day-info__hours">10 - 18 Uhr</span>
+                                                <br> <span class="day-info__label day-info__label--hours">Attraktionen:</span> <span class="day-info__hours">10 - 17 Uhr</span>
+                                                <br> </div>
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot-1 js-cal-day">
+                                            <div class="cal__daynumber">25</div>
+                                            <div class="js-cal-day-content" style="display: none">
+                                                <div class="day-info__header">Mittwoch, 25.09.2019</div> <span class="day-info__label day-info__label--hours">Park:</span> <span class="day-info__hours">10 - 18 Uhr</span>
+                                                <br> <span class="day-info__label day-info__label--hours">Attraktionen:</span> <span class="day-info__hours">10 - 17 Uhr</span>
+                                                <br> </div>
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot-1 js-cal-day">
+                                            <div class="cal__daynumber">26</div>
+                                            <div class="js-cal-day-content" style="display: none">
+                                                <div class="day-info__header">Donnerstag, 26.09.2019</div> <span class="day-info__label day-info__label--hours">Park:</span> <span class="day-info__hours">10 - 18 Uhr</span>
+                                                <br> <span class="day-info__label day-info__label--hours">Attraktionen:</span> <span class="day-info__hours">10 - 17 Uhr</span>
+                                                <br> </div>
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot-0 js-cal-day">
+                                            <div class="cal__daynumber">27</div>
+                                            <div class="js-cal-day-content" style="display: none">
+                                                <div class="day-info__header">Freitag, 27.09.2019</div>
+                                                <div class="day-info__label"> Park: geschlossen </div>
+                                                <div class="day-info__label"> Attraktionen: geschlossen </div>
+                                            </div>
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot-2 js-cal-day">
+                                            <div class="cal__daynumber">28</div>
+                                            <div class="js-cal-day-content" style="display: none">
+                                                <div class="day-info__header">Samstag, 28.09.2019</div> <span class="day-info__label day-info__label--hours">Park:</span> <span class="day-info__hours">10 - 19 Uhr</span>
+                                                <br> <span class="day-info__label day-info__label--hours">Attraktionen:</span> <span class="day-info__hours">10 - 18 Uhr</span>
+                                                <br> </div>
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot-2 js-cal-day">
+                                            <div class="cal__daynumber">29</div>
+                                            <div class="js-cal-day-content" style="display: none">
+                                                <div class="day-info__header">Sonntag, 29.09.2019</div> <span class="day-info__label day-info__label--hours">Park:</span> <span class="day-info__hours">10 - 19 Uhr</span>
+                                                <br> <span class="day-info__label day-info__label--hours">Attraktionen:</span> <span class="day-info__hours">10 - 18 Uhr</span>
+                                                <br> </div>
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                    </div>
+                                    <div class="cal__cell-row">
+                                        <div class="cal__cell cal__cell--slot-1 cal__cell--tag cal__cell--tag-vip-friends-special js-cal-day">
+                                            <div class="cal__daynumber">30</div>
+                                            <div class="js-cal-day-content" style="display: none">
+                                                <div class="day-info__header">Montag, 30.09.2019</div> <span class="day-info__label day-info__label--hours">Park:</span> <span class="day-info__hours">10 - 18 Uhr</span>
+                                                <br> <span class="day-info__label day-info__label--hours">Attraktionen:</span> <span class="day-info__hours">10 - 17 Uhr</span>
+                                                <br>
+                                                <div class="day-info__label"> <a href="/tickets/tages-tickets.html"> VIP Saisonpass: Freunde-Special </a> </div>
+                                            </div>
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="slider-item slick-slide">
+                                <div class="cal clearfix">
+                                    <div class="cal__header">
+                                        <div class="cal__month">Oktober 2019</div>
+                                        <div class="cal__header-cell">Mo</div>
+                                        <div class="cal__header-cell">Di</div>
+                                        <div class="cal__header-cell">Mi</div>
+                                        <div class="cal__header-cell">Do</div>
+                                        <div class="cal__header-cell">Fr</div>
+                                        <div class="cal__header-cell">Sa</div>
+                                        <div class="cal__header-cell">So</div>
+                                    </div>
+                                    <div class="cal__cell-row">
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot-1 cal__cell--tag cal__cell--tag-halloween js-cal-day">
+                                            <div class="cal__daynumber">1</div>
+                                            <div class="js-cal-day-content" style="display: none">
+                                                <div class="day-info__header">Dienstag, 01.10.2019</div> <span class="day-info__label day-info__label--hours">Park:</span> <span class="day-info__hours">10 - 18 Uhr</span>
+                                                <br> <span class="day-info__label day-info__label--hours">Attraktionen:</span> <span class="day-info__hours">10 - 17 Uhr</span>
+                                                <br>
+                                                <div class="day-info__label"> <a href="/attraktionen/events.html"> Halloween </a> </div>
+                                            </div>
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot-1 cal__cell--tag cal__cell--tag-halloween js-cal-day">
+                                            <div class="cal__daynumber">2</div>
+                                            <div class="js-cal-day-content" style="display: none">
+                                                <div class="day-info__header">Mittwoch, 02.10.2019</div> <span class="day-info__label day-info__label--hours">Park:</span> <span class="day-info__hours">10 - 18 Uhr</span>
+                                                <br> <span class="day-info__label day-info__label--hours">Attraktionen:</span> <span class="day-info__hours">10 - 17 Uhr</span>
+                                                <br>
+                                                <div class="day-info__label"> <a href="/attraktionen/events.html"> Halloween </a> </div>
+                                            </div>
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot-4 cal__cell--tag cal__cell--tag-halloween-horror cal__cell--tag cal__cell--tag-season-pass-exception js-cal-day">
+                                            <div class="cal__daynumber">3</div>
+                                            <div class="js-cal-day-content" style="display: none">
+                                                <div class="day-info__header">Donnerstag, 03.10.2019</div> <span class="day-info__label day-info__label--hours">Park:</span> <span class="day-info__hours">10 - 22 Uhr</span>
+                                                <br> <span class="day-info__label day-info__label--hours">Attraktionen:</span> <span class="day-info__hours">10 - 21 Uhr</span>
+                                                <br>
+                                                <div class="day-info__label"> <a href="/attraktionen/events.html"> Halloween mit Horror </a> </div>
+                                                <div class="day-info__label"> <a href="/tickets/tages-tickets.html"> Ausschlusstag (VIP-)Saisonpass </a> </div>
+                                            </div>
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot-2 cal__cell--tag cal__cell--tag-halloween js-cal-day">
+                                            <div class="cal__daynumber">4</div>
+                                            <div class="js-cal-day-content" style="display: none">
+                                                <div class="day-info__header">Freitag, 04.10.2019</div> <span class="day-info__label day-info__label--hours">Park:</span> <span class="day-info__hours">10 - 19 Uhr</span>
+                                                <br> <span class="day-info__label day-info__label--hours">Attraktionen:</span> <span class="day-info__hours">10 - 18 Uhr</span>
+                                                <br>
+                                                <div class="day-info__label"> <a href="/attraktionen/events.html"> Halloween </a> </div>
+                                            </div>
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot-4 cal__cell--tag cal__cell--tag-halloween-horror js-cal-day">
+                                            <div class="cal__daynumber">5</div>
+                                            <div class="js-cal-day-content" style="display: none">
+                                                <div class="day-info__header">Samstag, 05.10.2019</div> <span class="day-info__label day-info__label--hours">Park:</span> <span class="day-info__hours">10 - 22 Uhr</span>
+                                                <br> <span class="day-info__label day-info__label--hours">Attraktionen:</span> <span class="day-info__hours">10 - 21 Uhr</span>
+                                                <br>
+                                                <div class="day-info__label"> <a href="/attraktionen/events.html"> Halloween mit Horror </a> </div>
+                                            </div>
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot-2 cal__cell--tag cal__cell--tag-halloween js-cal-day">
+                                            <div class="cal__daynumber">6</div>
+                                            <div class="js-cal-day-content" style="display: none">
+                                                <div class="day-info__header">Sonntag, 06.10.2019</div> <span class="day-info__label day-info__label--hours">Park:</span> <span class="day-info__hours">10 - 19 Uhr</span>
+                                                <br> <span class="day-info__label day-info__label--hours">Attraktionen:</span> <span class="day-info__hours">10 - 18 Uhr</span>
+                                                <br>
+                                                <div class="day-info__label"> <a href="/attraktionen/events.html"> Halloween </a> </div>
+                                            </div>
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                    </div>
+                                    <div class="cal__cell-row">
+                                        <div class="cal__cell cal__cell--slot-2 cal__cell--tag cal__cell--tag-halloween js-cal-day">
+                                            <div class="cal__daynumber">7</div>
+                                            <div class="js-cal-day-content" style="display: none">
+                                                <div class="day-info__header">Montag, 07.10.2019</div> <span class="day-info__label day-info__label--hours">Park:</span> <span class="day-info__hours">10 - 19 Uhr</span>
+                                                <br> <span class="day-info__label day-info__label--hours">Attraktionen:</span> <span class="day-info__hours">10 - 18 Uhr</span>
+                                                <br>
+                                                <div class="day-info__label"> <a href="/attraktionen/events.html"> Halloween </a> </div>
+                                            </div>
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot-2 cal__cell--tag cal__cell--tag-halloween js-cal-day">
+                                            <div class="cal__daynumber">8</div>
+                                            <div class="js-cal-day-content" style="display: none">
+                                                <div class="day-info__header">Dienstag, 08.10.2019</div> <span class="day-info__label day-info__label--hours">Park:</span> <span class="day-info__hours">10 - 19 Uhr</span>
+                                                <br> <span class="day-info__label day-info__label--hours">Attraktionen:</span> <span class="day-info__hours">10 - 18 Uhr</span>
+                                                <br>
+                                                <div class="day-info__label"> <a href="/attraktionen/events.html"> Halloween </a> </div>
+                                            </div>
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot-2 cal__cell--tag cal__cell--tag-halloween js-cal-day">
+                                            <div class="cal__daynumber">9</div>
+                                            <div class="js-cal-day-content" style="display: none">
+                                                <div class="day-info__header">Mittwoch, 09.10.2019</div> <span class="day-info__label day-info__label--hours">Park:</span> <span class="day-info__hours">10 - 19 Uhr</span>
+                                                <br> <span class="day-info__label day-info__label--hours">Attraktionen:</span> <span class="day-info__hours">10 - 18 Uhr</span>
+                                                <br>
+                                                <div class="day-info__label"> <a href="/attraktionen/events.html"> Halloween </a> </div>
+                                            </div>
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot-2 cal__cell--tag cal__cell--tag-halloween js-cal-day">
+                                            <div class="cal__daynumber">10</div>
+                                            <div class="js-cal-day-content" style="display: none">
+                                                <div class="day-info__header">Donnerstag, 10.10.2019</div> <span class="day-info__label day-info__label--hours">Park:</span> <span class="day-info__hours">10 - 19 Uhr</span>
+                                                <br> <span class="day-info__label day-info__label--hours">Attraktionen:</span> <span class="day-info__hours">10 - 18 Uhr</span>
+                                                <br>
+                                                <div class="day-info__label"> <a href="/attraktionen/events.html"> Halloween </a> </div>
+                                            </div>
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot-2 cal__cell--tag cal__cell--tag-halloween js-cal-day">
+                                            <div class="cal__daynumber">11</div>
+                                            <div class="js-cal-day-content" style="display: none">
+                                                <div class="day-info__header">Freitag, 11.10.2019</div> <span class="day-info__label day-info__label--hours">Park:</span> <span class="day-info__hours">10 - 19 Uhr</span>
+                                                <br> <span class="day-info__label day-info__label--hours">Attraktionen:</span> <span class="day-info__hours">10 - 18 Uhr</span>
+                                                <br>
+                                                <div class="day-info__label"> <a href="/attraktionen/events.html"> Halloween </a> </div>
+                                            </div>
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot-4 cal__cell--tag cal__cell--tag-halloween-horror cal__cell--tag cal__cell--tag-season-pass-exception cal__cell--tag cal__cell--tag-merlin-pass-exception js-cal-day">
+                                            <div class="cal__daynumber">12</div>
+                                            <div class="js-cal-day-content" style="display: none">
+                                                <div class="day-info__header">Samstag, 12.10.2019</div> <span class="day-info__label day-info__label--hours">Park:</span> <span class="day-info__hours">10 - 22 Uhr</span>
+                                                <br> <span class="day-info__label day-info__label--hours">Attraktionen:</span> <span class="day-info__hours">10 - 21 Uhr</span>
+                                                <br>
+                                                <div class="day-info__label"> <a href="/attraktionen/events.html"> Halloween mit Horror </a> </div>
+                                                <div class="day-info__label"> <a href="/tickets/tages-tickets.html"> Ausschlusstag (VIP-)Saisonpass </a> </div>
+                                                <div class="day-info__label"> <a href="/tickets/tages-tickets.html"> Ausschlusstag Merlin Jahreskarte </a> </div>
+                                            </div>
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot-2 cal__cell--tag cal__cell--tag-halloween js-cal-day">
+                                            <div class="cal__daynumber">13</div>
+                                            <div class="js-cal-day-content" style="display: none">
+                                                <div class="day-info__header">Sonntag, 13.10.2019</div> <span class="day-info__label day-info__label--hours">Park:</span> <span class="day-info__hours">10 - 19 Uhr</span>
+                                                <br> <span class="day-info__label day-info__label--hours">Attraktionen:</span> <span class="day-info__hours">10 - 18 Uhr</span>
+                                                <br>
+                                                <div class="day-info__label"> <a href="/attraktionen/events.html"> Halloween </a> </div>
+                                            </div>
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                    </div>
+                                    <div class="cal__cell-row">
+                                        <div class="cal__cell cal__cell--slot-2 cal__cell--tag cal__cell--tag-halloween js-cal-day">
+                                            <div class="cal__daynumber">14</div>
+                                            <div class="js-cal-day-content" style="display: none">
+                                                <div class="day-info__header">Montag, 14.10.2019</div> <span class="day-info__label day-info__label--hours">Park:</span> <span class="day-info__hours">10 - 19 Uhr</span>
+                                                <br> <span class="day-info__label day-info__label--hours">Attraktionen:</span> <span class="day-info__hours">10 - 18 Uhr</span>
+                                                <br>
+                                                <div class="day-info__label"> <a href="/attraktionen/events.html"> Halloween </a> </div>
+                                            </div>
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot-2 cal__cell--tag cal__cell--tag-halloween js-cal-day">
+                                            <div class="cal__daynumber">15</div>
+                                            <div class="js-cal-day-content" style="display: none">
+                                                <div class="day-info__header">Dienstag, 15.10.2019</div> <span class="day-info__label day-info__label--hours">Park:</span> <span class="day-info__hours">10 - 19 Uhr</span>
+                                                <br> <span class="day-info__label day-info__label--hours">Attraktionen:</span> <span class="day-info__hours">10 - 18 Uhr</span>
+                                                <br>
+                                                <div class="day-info__label"> <a href="/attraktionen/events.html"> Halloween </a> </div>
+                                            </div>
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot-2 cal__cell--tag cal__cell--tag-halloween js-cal-day">
+                                            <div class="cal__daynumber">16</div>
+                                            <div class="js-cal-day-content" style="display: none">
+                                                <div class="day-info__header">Mittwoch, 16.10.2019</div> <span class="day-info__label day-info__label--hours">Park:</span> <span class="day-info__hours">10 - 19 Uhr</span>
+                                                <br> <span class="day-info__label day-info__label--hours">Attraktionen:</span> <span class="day-info__hours">10 - 18 Uhr</span>
+                                                <br>
+                                                <div class="day-info__label"> <a href="/attraktionen/events.html"> Halloween </a> </div>
+                                            </div>
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot-2 cal__cell--tag cal__cell--tag-halloween js-cal-day">
+                                            <div class="cal__daynumber">17</div>
+                                            <div class="js-cal-day-content" style="display: none">
+                                                <div class="day-info__header">Donnerstag, 17.10.2019</div> <span class="day-info__label day-info__label--hours">Park:</span> <span class="day-info__hours">10 - 19 Uhr</span>
+                                                <br> <span class="day-info__label day-info__label--hours">Attraktionen:</span> <span class="day-info__hours">10 - 18 Uhr</span>
+                                                <br>
+                                                <div class="day-info__label"> <a href="/attraktionen/events.html"> Halloween </a> </div>
+                                            </div>
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot-2 cal__cell--tag cal__cell--tag-halloween js-cal-day">
+                                            <div class="cal__daynumber">18</div>
+                                            <div class="js-cal-day-content" style="display: none">
+                                                <div class="day-info__header">Freitag, 18.10.2019</div> <span class="day-info__label day-info__label--hours">Park:</span> <span class="day-info__hours">10 - 19 Uhr</span>
+                                                <br> <span class="day-info__label day-info__label--hours">Attraktionen:</span> <span class="day-info__hours">10 - 18 Uhr</span>
+                                                <br>
+                                                <div class="day-info__label"> <a href="/attraktionen/events.html"> Halloween </a> </div>
+                                            </div>
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot-4 cal__cell--tag cal__cell--tag-halloween-horror cal__cell--tag cal__cell--tag-season-pass-exception cal__cell--tag cal__cell--tag-merlin-pass-exception js-cal-day">
+                                            <div class="cal__daynumber">19</div>
+                                            <div class="js-cal-day-content" style="display: none">
+                                                <div class="day-info__header">Samstag, 19.10.2019</div> <span class="day-info__label day-info__label--hours">Park:</span> <span class="day-info__hours">10 - 22 Uhr</span>
+                                                <br> <span class="day-info__label day-info__label--hours">Attraktionen:</span> <span class="day-info__hours">10 - 21 Uhr</span>
+                                                <br>
+                                                <div class="day-info__label"> <a href="/attraktionen/events.html"> Halloween mit Horror </a> </div>
+                                                <div class="day-info__label"> <a href="/tickets/tages-tickets.html"> Ausschlusstag (VIP-)Saisonpass </a> </div>
+                                                <div class="day-info__label"> <a href="/tickets/tages-tickets.html"> Ausschlusstag Merlin Jahreskarte </a> </div>
+                                            </div>
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot-2 cal__cell--tag cal__cell--tag-halloween js-cal-day">
+                                            <div class="cal__daynumber">20</div>
+                                            <div class="js-cal-day-content" style="display: none">
+                                                <div class="day-info__header">Sonntag, 20.10.2019</div> <span class="day-info__label day-info__label--hours">Park:</span> <span class="day-info__hours">10 - 19 Uhr</span>
+                                                <br> <span class="day-info__label day-info__label--hours">Attraktionen:</span> <span class="day-info__hours">10 - 18 Uhr</span>
+                                                <br>
+                                                <div class="day-info__label"> <a href="/attraktionen/events.html"> Halloween </a> </div>
+                                            </div>
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                    </div>
+                                    <div class="cal__cell-row">
+                                        <div class="cal__cell cal__cell--slot-1 cal__cell--tag cal__cell--tag-halloween js-cal-day">
+                                            <div class="cal__daynumber">21</div>
+                                            <div class="js-cal-day-content" style="display: none">
+                                                <div class="day-info__header">Montag, 21.10.2019</div> <span class="day-info__label day-info__label--hours">Park:</span> <span class="day-info__hours">10 - 18 Uhr</span>
+                                                <br> <span class="day-info__label day-info__label--hours">Attraktionen:</span> <span class="day-info__hours">10 - 17 Uhr</span>
+                                                <br>
+                                                <div class="day-info__label"> <a href="/attraktionen/events.html"> Halloween </a> </div>
+                                            </div>
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot-1 cal__cell--tag cal__cell--tag-halloween js-cal-day">
+                                            <div class="cal__daynumber">22</div>
+                                            <div class="js-cal-day-content" style="display: none">
+                                                <div class="day-info__header">Dienstag, 22.10.2019</div> <span class="day-info__label day-info__label--hours">Park:</span> <span class="day-info__hours">10 - 18 Uhr</span>
+                                                <br> <span class="day-info__label day-info__label--hours">Attraktionen:</span> <span class="day-info__hours">10 - 17 Uhr</span>
+                                                <br>
+                                                <div class="day-info__label"> <a href="/attraktionen/events.html"> Halloween </a> </div>
+                                            </div>
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot-1 cal__cell--tag cal__cell--tag-halloween js-cal-day">
+                                            <div class="cal__daynumber">23</div>
+                                            <div class="js-cal-day-content" style="display: none">
+                                                <div class="day-info__header">Mittwoch, 23.10.2019</div> <span class="day-info__label day-info__label--hours">Park:</span> <span class="day-info__hours">10 - 18 Uhr</span>
+                                                <br> <span class="day-info__label day-info__label--hours">Attraktionen:</span> <span class="day-info__hours">10 - 17 Uhr</span>
+                                                <br>
+                                                <div class="day-info__label"> <a href="/attraktionen/events.html"> Halloween </a> </div>
+                                            </div>
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot-1 cal__cell--tag cal__cell--tag-halloween js-cal-day">
+                                            <div class="cal__daynumber">24</div>
+                                            <div class="js-cal-day-content" style="display: none">
+                                                <div class="day-info__header">Donnerstag, 24.10.2019</div> <span class="day-info__label day-info__label--hours">Park:</span> <span class="day-info__hours">10 - 18 Uhr</span>
+                                                <br> <span class="day-info__label day-info__label--hours">Attraktionen:</span> <span class="day-info__hours">10 - 17 Uhr</span>
+                                                <br>
+                                                <div class="day-info__label"> <a href="/attraktionen/events.html"> Halloween </a> </div>
+                                            </div>
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot-1 cal__cell--tag cal__cell--tag-halloween js-cal-day">
+                                            <div class="cal__daynumber">25</div>
+                                            <div class="js-cal-day-content" style="display: none">
+                                                <div class="day-info__header">Freitag, 25.10.2019</div> <span class="day-info__label day-info__label--hours">Park:</span> <span class="day-info__hours">10 - 18 Uhr</span>
+                                                <br> <span class="day-info__label day-info__label--hours">Attraktionen:</span> <span class="day-info__hours">10 - 17 Uhr</span>
+                                                <br>
+                                                <div class="day-info__label"> <a href="/attraktionen/events.html"> Halloween </a> </div>
+                                            </div>
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot-4 cal__cell--tag cal__cell--tag-halloween-horror cal__cell--tag cal__cell--tag-season-pass-exception cal__cell--tag cal__cell--tag-merlin-pass-exception js-cal-day">
+                                            <div class="cal__daynumber">26</div>
+                                            <div class="js-cal-day-content" style="display: none">
+                                                <div class="day-info__header">Samstag, 26.10.2019</div> <span class="day-info__label day-info__label--hours">Park:</span> <span class="day-info__hours">10 - 22 Uhr</span>
+                                                <br> <span class="day-info__label day-info__label--hours">Attraktionen:</span> <span class="day-info__hours">10 - 21 Uhr</span>
+                                                <br>
+                                                <div class="day-info__label"> <a href="/attraktionen/events.html"> Halloween mit Horror </a> </div>
+                                                <div class="day-info__label"> <a href="/tickets/tages-tickets.html"> Ausschlusstag (VIP-)Saisonpass </a> </div>
+                                                <div class="day-info__label"> <a href="/tickets/tages-tickets.html"> Ausschlusstag Merlin Jahreskarte </a> </div>
+                                            </div>
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot-1 cal__cell--tag cal__cell--tag-halloween js-cal-day">
+                                            <div class="cal__daynumber">27</div>
+                                            <div class="js-cal-day-content" style="display: none">
+                                                <div class="day-info__header">Sonntag, 27.10.2019</div> <span class="day-info__label day-info__label--hours">Park:</span> <span class="day-info__hours">10 - 18 Uhr</span>
+                                                <br> <span class="day-info__label day-info__label--hours">Attraktionen:</span> <span class="day-info__hours">10 - 17 Uhr</span>
+                                                <br>
+                                                <div class="day-info__label"> <a href="/attraktionen/events.html"> Halloween </a> </div>
+                                            </div>
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                    </div>
+                                    <div class="cal__cell-row">
+                                        <div class="cal__cell cal__cell--slot-0 js-cal-day">
+                                            <div class="cal__daynumber">28</div>
+                                            <div class="js-cal-day-content" style="display: none">
+                                                <div class="day-info__header">Montag, 28.10.2019</div>
+                                                <div class="day-info__label"> Park: geschlossen </div>
+                                                <div class="day-info__label"> Attraktionen: geschlossen </div>
+                                            </div>
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot-0 js-cal-day">
+                                            <div class="cal__daynumber">29</div>
+                                            <div class="js-cal-day-content" style="display: none">
+                                                <div class="day-info__header">Dienstag, 29.10.2019</div>
+                                                <div class="day-info__label"> Park: geschlossen </div>
+                                                <div class="day-info__label"> Attraktionen: geschlossen </div>
+                                            </div>
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot-0 js-cal-day">
+                                            <div class="cal__daynumber">30</div>
+                                            <div class="js-cal-day-content" style="display: none">
+                                                <div class="day-info__header">Mittwoch, 30.10.2019</div>
+                                                <div class="day-info__label"> Park: geschlossen </div>
+                                                <div class="day-info__label"> Attraktionen: geschlossen </div>
+                                            </div>
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot-4 cal__cell--tag cal__cell--tag-halloween-horror cal__cell--tag cal__cell--tag-season-pass-exception js-cal-day">
+                                            <div class="cal__daynumber">31</div>
+                                            <div class="js-cal-day-content" style="display: none">
+                                                <div class="day-info__header">Donnerstag, 31.10.2019</div> <span class="day-info__label day-info__label--hours">Park:</span> <span class="day-info__hours">10 - 22 Uhr</span>
+                                                <br> <span class="day-info__label day-info__label--hours">Attraktionen:</span> <span class="day-info__hours">10 - 21 Uhr</span>
+                                                <br>
+                                                <div class="day-info__label"> <a href="/attraktionen/events.html"> Halloween mit Horror </a> </div>
+                                                <div class="day-info__label"> <a href="/tickets/tages-tickets.html"> Ausschlusstag (VIP-)Saisonpass </a> </div>
+                                            </div>
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="slider-item slick-slide">
+                                <div class="cal clearfix">
+                                    <div class="cal__header">
+                                        <div class="cal__month">November 2019</div>
+                                        <div class="cal__header-cell">Mo</div>
+                                        <div class="cal__header-cell">Di</div>
+                                        <div class="cal__header-cell">Mi</div>
+                                        <div class="cal__header-cell">Do</div>
+                                        <div class="cal__header-cell">Fr</div>
+                                        <div class="cal__header-cell">Sa</div>
+                                        <div class="cal__header-cell">So</div>
+                                    </div>
+                                    <div class="cal__cell-row">
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot-1 js-cal-day">
+                                            <div class="cal__daynumber">1</div>
+                                            <div class="js-cal-day-content" style="display: none">
+                                                <div class="day-info__header">Freitag, 01.11.2019</div> <span class="day-info__label day-info__label--hours">Park:</span> <span class="day-info__hours">10 - 18 Uhr</span>
+                                                <br> <span class="day-info__label day-info__label--hours">Attraktionen:</span> <span class="day-info__hours">10 - 17 Uhr</span>
+                                                <br> </div>
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot-1 js-cal-day">
+                                            <div class="cal__daynumber">2</div>
+                                            <div class="js-cal-day-content" style="display: none">
+                                                <div class="day-info__header">Samstag, 02.11.2019</div> <span class="day-info__label day-info__label--hours">Park:</span> <span class="day-info__hours">10 - 18 Uhr</span>
+                                                <br> <span class="day-info__label day-info__label--hours">Attraktionen:</span> <span class="day-info__hours">10 - 17 Uhr</span>
+                                                <br> </div>
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot-1 js-cal-day">
+                                            <div class="cal__daynumber">3</div>
+                                            <div class="js-cal-day-content" style="display: none">
+                                                <div class="day-info__header">Sonntag, 03.11.2019</div> <span class="day-info__label day-info__label--hours">Park:</span> <span class="day-info__hours">10 - 18 Uhr</span>
+                                                <br> <span class="day-info__label day-info__label--hours">Attraktionen:</span> <span class="day-info__hours">10 - 17 Uhr</span>
+                                                <br> </div>
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                    </div>
+                                    <div class="cal__cell-row">
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                    </div>
+                                    <div class="cal__cell-row">
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                    </div>
+                                    <div class="cal__cell-row">
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                    </div>
+                                    <div class="cal__cell-row">
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="slider-item slick-slide">
+                                <div class="cal clearfix">
+                                    <div class="cal__header">
+                                        <div class="cal__month">Dezember 2019</div>
+                                        <div class="cal__header-cell">Mo</div>
+                                        <div class="cal__header-cell">Di</div>
+                                        <div class="cal__header-cell">Mi</div>
+                                        <div class="cal__header-cell">Do</div>
+                                        <div class="cal__header-cell">Fr</div>
+                                        <div class="cal__header-cell">Sa</div>
+                                        <div class="cal__header-cell">So</div>
+                                    </div>
+                                    <div class="cal__cell-row">
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                    </div>
+                                    <div class="cal__cell-row">
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                    </div>
+                                    <div class="cal__cell-row">
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                    </div>
+                                    <div class="cal__cell-row">
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                    </div>
+                                    <div class="cal__cell-row">
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                    </div>
+                                    <div class="cal__cell-row">
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                        <div class="cal__cell cal__cell--slot- js-cal-day"> &nbsp;
+                                            <div class="cal__cell__hl"></div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <!-- .slick-slider -->
+                    </div>
+                </div>
+                <div class="row">
+                    <div class="column">
+                        <div class="day-info js-day-info">
+                            <div class="day-info__main-header">Alle Infos für deinen ausgewählten Tag</div>
+                            <div class="day-info__inner js-day-info-content"> </div> <a href="/tickets/tages-tickets.html" class="btn btn--small font-secondary">Jetzt Tickets Buchen</a> </div>
+                    </div>
+                </div>
+                <div class="row">
+                    <div class="columns">
+                        <div class="calendar-legends">
+                            <div class="calendar-legend">
+                                <div class="cal-icon cal-icon--halloween"></div>
+                                <div class="calendar-legend__text">Halloween</div>
+                            </div>
+                            <div class="calendar-legend">
+                                <div class="cal-icon cal-icon--halloween-horror"></div>
+                                <div class="calendar-legend__text">Halloween mit Horror</div>
+                            </div>
+                            <!--<div class="calendar-legend"> <div class="cal-icon cal-icon--pyro"></div> <div class="calendar-legend__text">Pyro Games</div> </div>-->
+                            <div class="calendar-legend">
+                                <div class="cal-icon cal-icon--long-summer"></div>
+                                <div class="calendar-legend__text">XXL-Sommertage</div>
+                            </div>
+                            <div class="calendar-legend">
+                                <div class="cal-icon cal-icon--zombie-escape"></div>
+                                <div class="calendar-legend__text">Zombie Escape</div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="row">
+                    <div class="columns">
+                        <div class="calendar-legends">
+                            <div class="calendar-legend">
+                                <div class="legend-triangle legend-triangle--tag-friends-special"></div>
+                                <div class="calendar-legend__text">VIP Saisonpass:
+                                    <br> Freunde-Special gültig</div>
+                            </div>
+                            <div class="calendar-legend">
+                                <div class="legend-triangle legend-triangle--tag-season-pass"></div>
+                                <div class="calendar-legend__text">Ausschlusstag
+                                    <br> (VIP-)Saisonpass<sup>1</sup></div>
+                            </div>
+                            <div class="calendar-legend">
+                                <div class="cal-icon cal-icon--tag-marlin-pass"></div>
+                                <div class="calendar-legend__text">Ausschlusstag
+                                    <br> Merlin Jahreskarte<sup>1</sup></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div id="c9103" class="ce ce-text">
+                    <div class="bodytext-wrap">
+                        <p class="align-center"><em>*&nbsp;Achtung, Schließtage beachten! 06.09., 13.09., 20.09., 27.09., 28./29./30.10. (Änderungen der Saisonzeiten 2019 vorbehalten)</em></p>
+                        <p class="align-center"><em>¹ Erlebt mit dem VIP Saisonpass bzw. der Merlin Standard Jahreskarte die ausgeschlossenen Halloween-Tage für nur 9€ Zuzahlung pro Tag.</em></p>
+                    </div>
+                </div>
+                <div id="c10661" class="ce ce-text">
+                    <div class="bodytext-wrap">
+                        <p class="align-center">&nbsp;</p>
+                        <p class="align-center"><em>Die Inbetriebnahme einiger unserer Fahrgeschäfte ist grundsätzlich temperatur- und wetterabhängig. </em></p>
+                        <p class="align-center"><em>Je nach Wetterlage kann es – auch bei den Großfahrgeschäften - zu verspäteter Inbetriebnahme oder sogar zu Komplettausfällen kommen. </em></p>
+                        <p class="align-center"><em>Vielen Dank für Euer Verständnis.</em></p>
+                    </div>
+                </div>
+                <section id="c9122" class="basesection basesection--lesspadding " style="">
+                    <div class="row">
+                        <div class="small-12 medium-10 medium-centered columns">
+                            <section>
+                                <ul class="accordion">
+                                    <li class="accordion__list-element accordion-navigation">
+                                        <h5 class="accordion__list-element__headline std-header--lvlfive js-accordion trck-accordion" data-trck-title="Anreise mit dem eigenen PKW-ID9106"><span>Anreise mit dem eigenen PKW</span></h5>
+                                        <div class="accordion__content">
+                                            <div id="c9106" class="ce ce-text">
+                                                <h3 class="subpage-header ">Anreise mit dem eigenen PKW</h3>
+                                                <div class="bodytext-wrap">
+                                                    <p class="bodytext">Wenn Du mit dem Auto anreist, fährst Du über die A7 und&nbsp;nimmst die Abfahrt Soltau-Ost. Von dort aus ist der Weg zum Heide Park Resort ausgeschildert.</p>
+                                                    <p class="bodytext">Zum Heide Park Resort&nbsp;gehören&nbsp;zwei große Parkplätze mit Platz für ca. 300 Busse / Wohnmobile und etwa 8.000 PKW. Für Wohnmobile und PKWs erheben wir eine Parkgebühr von 6,00 €. Die Parkgebühr kannst Du sowohl bar, als auch &quot;bargeldlos&quot; direkt am Parkplatz bezahlen. (<em>Änderungen vorbehalten</em>)&nbsp;</p>
+                                                    <p class="bodytext">Als Übernachtungsgast parkst Du kostenlos auf dem Parkplatz des Heide Park Abenteuerhotels oder dem Parkplatz des Holiday Camps. Zeige bei der Einfahrt einfach Deine Buchungsbestätigung vor.</p>
+                                                    <p class="bodytext">&nbsp;</p>
+                                                    <p class="bodytext"><strong>Eingabe Navigationssystem:</strong>
+                                                        <br /> Sonderziele - Freizeitparks</p>
+                                                    <p class="bodytext"><strong>Adresse:</strong>
+                                                        <br /> Heide Park 1
+                                                        <br /> 29614 Soltau</p>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </li>
+                                    <li class="accordion__list-element accordion-navigation">
+                                        <h5 class="accordion__list-element__headline std-header--lvlfive js-accordion trck-accordion" data-trck-title="Anreise mit dem Bus-ID9109"><span>Anreise mit dem Bus</span></h5>
+                                        <div class="accordion__content">
+                                            <div id="c9109" class="ce ce-text">
+                                                <h3 class="subpage-header ">Anreise mit dem Bus</h3>
+                                                <div class="bodytext-wrap">
+                                                    <p class="bodytext">Du kannst&nbsp;das Heide Park Resort auch bequem mit dem Bus erreichen. Vom Bahnhof Soltau (HAN) aus gibt es Busverbindungen zum Heide Park Resort. <a href="/fileadmin/content/verschiedenes/Prueser_Bus_bis_31.07.2018.pdf">(</a><a href="/fileadmin/content/verschiedenes/Prueser_und_Linie_150_2019.pdf" target="_blank">Linie 150&nbsp;&amp; Busunternehmen Prüser</a><a href="/fileadmin/content/verschiedenes/Prueser_Bus_bis_31.07.2018.pdf">)</a>.</p>
+                                                    <p class="bodytext">Direktverbindungen zum Heide Park Resort und zurück gibt es zum Beispiel auch aus:&nbsp;</p>
+                                                    <ul class="list--subpage">
+                                                        <li><a href="/fileadmin/content/verschiedenes/Buslinie_KVG_Hamburg__2019.pdf" target="_blank">Hamburg (KVG)&nbsp;- www.kvg-bus.de&nbsp;</a></li>
+                                                        <li><a href="/fileadmin/content/verschiedenes/Flixbus_2019.pdf" target="_blank">Hamburg - FlixBus</a></li>
+                                                    </ul>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </li>
+                                    <li class="accordion__list-element accordion-navigation">
+                                        <h5 class="accordion__list-element__headline std-header--lvlfive js-accordion trck-accordion" data-trck-title="Anreise mit der Bahn-ID9112"><span>Anreise mit der Bahn</span></h5>
+                                        <div class="accordion__content">
+                                            <div id="c9112" class="ce ce-text">
+                                                <h3 class="subpage-header ">Anreise mit der Bahn</h3>
+                                                <div class="bodytext-wrap">
+                                                    <p class="bodytext">Du kannst&nbsp;das Heide Park Resort auch bequem mit der Bahn (<a href="http://www.bahn.de/" title="Opens external link in new window" target="_blank">www.bahn.de</a> oder <a href="http://www.erixx.de/" title="Opens external link in new window" target="_blank">www.erixx.de</a>) erreichen.</p>
+                                                    <p class="bodytext">Deine&nbsp;Zielbahnhöfe mit der Bahnanreise sind Soltau (HAN) oder Wolterdingen (HAN). Von Soltau (HAN) aus gibt es Busverbindungen zum Heide Park Resort&nbsp;(Linie 154 &amp; Busunternehmen Prüser) und von Wolterdingen (HAN)&nbsp;bist Du zu Fuß in ca. 20&nbsp;Minuten im Heide Park Resort. Wenn Du aus Hamburg kommst, empfehlen wir Dir in Wolterdingen (HAN) auszusteigen und weiter zu Fuß in das Heide Park Resort&nbsp;zu laufen.</p>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </li>
+                                    <li class="accordion__list-element accordion-navigation">
+                                        <h5 class="accordion__list-element__headline std-header--lvlfive js-accordion trck-accordion" data-trck-title="Taschen- und Personenkontrollen-ID9105"><span>Taschen- und Personenkontrollen</span></h5>
+                                        <div class="accordion__content">
+                                            <div id="c9105" class="ce ce-text">
+                                                <h4 class="subpage-header ">Taschen- und Personenkontrollen</h4>
+                                                <div class="bodytext-wrap">
+                                                    <p class="bodytext">Wir haben unsere Sicherheitsauflagen angepasst und führen ab sofort Taschen- und Personenkontrollen am Parkeingang durch. Diese erfolgen nicht bei jedem Gast, sondern stichprobenartig. Um einen reibungslosen Ablauf zu garantieren, bitten wir unsere Gäste um Verständnis und Mithilfe. Die Taschen sind zur Kontrolle am Gate / Eingang bereitzuhalten. Bitte plant entsprechend Zeit für den Einlass bei Eurem Besuch ein. </p>
+                                                    <p class="bodytext">Eine Übersicht, welche Gegenstände nicht mit in die Abenteuerwelt genommen werden dürfen, findet Ihr <a href="/fileadmin/content/info/Heide_Park_Resort_Taschenkontrolle_Verbote.jpg" title="Initiates file download" target="_blank" class="download">hier</a>. </p>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </li>
+                                    <li class="accordion__list-element accordion-navigation">
+                                        <h5 class="accordion__list-element__headline std-header--lvlfive js-accordion trck-accordion" data-trck-title="Die Heide Park Resort App-ID9118"><span>Die Heide Park Resort App</span></h5>
+                                        <div class="accordion__content">
+                                            <div class="row">
+                                                <div class="infoteaser infoteaser__image small-12 medium-6 columns"> <img class="teaserbox__image js-tabarea-image infoteaser__mask__image" src="/fileadmin/_processed_/e/e/csm_180320-Knitter-HP-App_ed31f922fd.jpg" data-src="/fileadmin/_processed_/e/e/csm_180320-Knitter-HP-App_ed31f922fd.jpg" width="540" height="540" alt="" /> </div>
+                                                <div class="infoteaser infoteaser__text small-12 medium-6 columns">
+                                                    <div class="infoteaser__preheading font-tertiary"> Hol&#039; Dir das Abenteuer auf Dein Smartphone </div>
+                                                    <h2 class="std-header--lvltwo font-secondary infoteaser__text__heading">Die Heide Park Resort App</h2>
+                                                    <p class="infoteaser__text">Außergewöhnliche Abenteuer warten auf Dich im Heide Park Resort – erlebe die einzigartige Mischung aus Achterbahnen und Abenteuerwelten jetzt mit unserer einzigartigen App auf Deinem Smartphone – natürlich kostenlos!</p>
+                                                    <p class="infoteaser__text">Entdecke unter anderem folgende Funktionen:</p>
+                                                    <ul class="infoteaser__text__list list--std">
+                                                        <li class="infoteaser__text__listitem">Übersicht Wartezeiten</li>
+                                                        <li class="infoteaser__text__listitem">Interaktiver Parkplan</li>
+                                                        <li class="infoteaser__text__listitem">Attraktionsfinder</li>
+                                                        <li class="infoteaser__text__listitem">Showzeiten für Deinen Besuch</li>
+                                                    </ul>
+                                                    <div class="clearfix"> <a href="https://itunes.apple.com/de/app/heide-park-resort/id439867160?mt=8" target="_blank" class="btn--small infoteaser__button__store apple">Erhätlich im</a> <a href="https://play.google.com/store/apps/details?id=de.heide_park.heidepark" target="_blank" class="btn--small infoteaser__button__store google">Jetzt bei</a> </div>
+                                                </div>
+                                            </div>
+                                            <!-- .row -->
+                                        </div>
+                                    </li>
+                                </ul>
+                            </section>
+                        </div>
+                        <!-- .medium-8 -->
+                    </div>
+                    <!-- .row -->
+                </section>
+                <!--TYPO3SEARCH_end-->
+                <div class="toolbar toolbar--panel toolbar--panelfixed" onclick="void(0)">
+                    <div class="icon-panel parkplan">
+                        <a class="toolbar__parkplan" href="/fileadmin/content/info/HP_Parkplan_2019.jpg" target="_blank">
+                            <div class="toolbar__icon"></div> Parkplan </a>
+                    </div>
+                    <div class="icon-panel app">
+                        <a href="/infos/hilfefaq/internet-mobile-geraete.html#c989">
+                            <div class="toolbar__icon"></div> Heide Park
+                            <br/>App </a>
+                    </div>
+                    <div class="icon-panel holidays"> <a href="/gruppen-schulen.html"> Gruppen- <br/>Angebote </a> </div>
+                    <div class="icon-panel opening-hours">
+                        <a href="/infos/oeffnungszeiten-anreise.html">
+                            <div class="toolbar__icon"></div> Saison 2019:
+                            <p class="toolbar__timeentry"> 06.04. - 03.11.
+                                <br> (Schließtage beachten)</p>
+                        </a>
+                    </div>
+                    <div class="toolbar__flyout">
+                        <ul class="toolbar__flyoutlist">
+                            <li class="toolbar__flyoutitem toolbar__flyoutitem--plan">Parkplan</li>
+                            <li class="toolbar__flyoutitem toolbar__flyoutitem--app">Heide Park App</li>
+                            <li class="toolbar__flyoutitem toolbar__flyoutitem--holidays">Gruppenangebote</li>
+                            <li class="toolbar__flyoutitem toolbar__flyoutitem--hours">
+                                <div class="toolbar__linewrap"> <span class="toolbar__line"></span> <span class="toolbar__line"></span> <span class="toolbar__line"></span> <span class="toolbar__line"></span> </div> Öffnungszeiten </li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+            <!-- end role main -->
+            <!-- Begin Footer -->
+            <footer class="footer " role="contentinfo" data-sectiontitle="Service, Kontakt &amp; Info">
+                <section class="supportrow hide-for-small-only clearfix">
+                    <div class="row">
+                        <div class="columns">
+                            <div class="row footer__firstrow">
+                                <div class="footer__bubble medium-only-text-right">
+                                    <a href="/infos.html">
+                                        <div class="bubblewrap small">
+                                            <div class="bubble hero--small support"> <img class="bubble__image--small" src="/fileadmin/_processed_/4/5/csm_Heide_Park_Resort_Bigroundel_Service_39f4fafca8.jpg" data-src="/fileadmin/_processed_/4/5/csm_Heide_Park_Resort_Bigroundel_Service_39f4fafca8.jpg" width="176" height="176" alt="" /> </div>
+                                            <div class="badgewrap">
+                                                <div class="badge--icon help small"></div>
+                                                <div class="badge badge--small clearfix support">
+                                                    <div class="vertical-align">
+                                                        <div class="label font-secondary">Hilfe-Center</div>
+                                                        <div class="font-tertiary badge__subtitle--small">Alle Infos für Deinen Besuch</div>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </a>
+                                </div>
+                                <div class="footer__bubble medium-only-text-right">
+                                    <a href="/infos/oeffnungszeiten-anreise.html">
+                                        <div class="bubblewrap small">
+                                            <div class="bubble hero--small support"> <img class="bubble__image--small" src="/fileadmin/_processed_/a/f/csm_Heide_Park_Resort_Bigroundel-Anreise-Oeffnungszeiten_4bf5a55f4b.jpg" data-src="/fileadmin/_processed_/a/f/csm_Heide_Park_Resort_Bigroundel-Anreise-Oeffnungszeiten_4bf5a55f4b.jpg" width="176" height="176" alt="" /> </div>
+                                            <div class="badgewrap">
+                                                <div class="badge--icon route small"></div>
+                                                <div class="badge badge--small clearfix support">
+                                                    <div class="vertical-align">
+                                                        <div class="label font-secondary">Anreise</div>
+                                                        <div class="font-tertiary badge__subtitle--small">Mit Bus, Bahn oder PKW</div>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </a>
+                                </div>
+                                <div class="footer__box">
+                                    <div class="openinghours winter-break">
+                                        <div class="selector">
+                                            <ul class="tabs big" data-tab role="tablist">
+                                                <!-- check if today is before park opening 2018 -->
+                                                <!-- FOR WINTERBREAK ONLY -->
+                                                <li class="tab__title tab-title font-secondary active flex-grow" role="presentational">
+                                                    <a href="/infos/oeffnungszeiten-anreise.html">
+                                                        <div class="day font-secondary"> Saison 2019 </div>
+                                                    </a>
+                                                </li>
+                                            </ul>
+                                        </div>
+                                        <div class="tabs-content">
+                                            <a href="/infos/oeffnungszeiten-anreise.html" style="display: block; color: #333!important; padding: 1px 0;">
+                                                <h3 class="t-m20">06. April - 03. November</h3>
+                                                <p> <strong>Schließtage:</strong>
+                                                    <br/> 06.09., 13.09., 20.09., 27.09., 28./29./30.10. </p>
+                                            </a>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </section>
+                <section class="navigation ">
+                    <div class="row">
+                        <div class="small-12 medium-12 large-5 columns">
+                            <div class="row">
+                                <div class="small-6 footlogo medium-only-text-right columns">
+                                    <a href="#"> <img src="/typo3conf/ext/p2p/Resources/Public/assets_dist/img/logo.png" class="logo" alt="Heidepark Logo" width="245" height="155" /> </a>
+                                </div>
+                                <div class="small-6 columns">
+                                    <div class="contactdetails">
+                                        <div class="details">
+                                            <div class="title"> Service, Kontakt &amp; Info </div> <a class="details__number" href="tel:+491806919101"> 01806 - 91 91 01* </a> </div>
+                                        <div class="details">
+                                            <div class="title"> Service-Fax </div> <a class="details__number disabled" href="#"> 01805 - 54 58 01* </a> </div>
+                                        <div class="details">
+                                            <div class="title"> E-Mail </div> <a href="javascript:linkTo_UnCryptMailto('nbjmup+jogpAifjef.qbsl\/ef');">info(at)heide-park.de</a> </div>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="row">
+                                <div class="medium-9 medium-centered large-12 large-offset-0 hide-for-small-only columns newsletter">
+                                    <div class="title">Newsletter abonnieren</div>
+                                    <div class="inline-form newsletter-form clearfix">
+                                        <input type="text" placeholder="E-Mail-Adresse" data-id="js-newsletter-footer-mail" class="input--rndlft newsletter-field" /> <a href="#" class="btn--rndrgt newsletter-submit font-secondary js-newsletter-modal-submit" data-input-id="js-newsletter-footer-mail" data-iframe-id="footer-nl-iframe" data-reveal-id="newsletter__modal">Anmelden</a> </div>
+                                    <div id="newsletter__modal" class="newsletter__modal reveal-modal" data-reveal aria-labelledby="modalTitle" aria-hidden="true" role="dialog">
+                                        <div class="newsletter__modal__inner">
+                                            <iframe class="iframe iframe--newsletter js-iframe-newsletter" data-src="/iframes/newsletter.html" frameborder="0" data-id="footer-nl-iframe"></iframe>
+                                        </div> <a href="#" class="close-reveal-modal" aria-label="Close">&#215;</a> </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="medium-12 large-7 columns">
+                            <div class="row">
+                                <div class="small-4 columns hide-for-small-only">
+                                    <ul>
+                                        <li class="title"> <a href="/attraktionen/attraktionsfinder.html">Attraktionen</a></li>
+                                        <li> <a href="/attraktionen/detail/flug-der-daemonen.html"> Flug der Dämonen</a> </li>
+                                        <li> <a href="/attraktionen/detail/desert-race.html"> Desert Race</a> </li>
+                                        <li> <a href="/attraktionen/detail/topilaula-schlacht.html"> ToPiLauLa-Schlacht</a> </li>
+                                        <li> <a href="/attraktionen/detail/indy-blitz.html"> Indy-Blitz</a> </li>
+                                        <li> <a href="/attraktionen/detail/big-loop.html"> Big Loop</a> </li>
+                                        <li> <a href="/attraktionen/detail/mountain-rafting.html"> Mountain-Rafting</a> </li>
+                                        <li> <a href="/attraktionen/detail/screamie.html"> Screamie</a> </li>
+                                        <li> <a href="/attraktionen/detail/krake.html"> KRAKE</a> </li>
+                                    </ul>
+                                </div>
+                                <div class="small-6 medium-4 columns">
+                                    <ul>
+                                        <li class="title"> <a href="/kurzurlaub.html">Übernachten</a> </li>
+                                        <li> <a href="/kurzurlaub/abenteuerhotel.html" title="Abenteuerhotel">Abenteuerhotel</a> </li>
+                                        <li> <a href="/kurzurlaub/holiday-camp.html" title="Holiday Camp">Holiday Camp</a> </li>
+                                    </ul>
+                                    <ul>
+                                        <li class="title"> <a href="/tickets.html">Tickets &amp; Preise</a> </li>
+                                        <li> <a href="/tickets/tages-tickets.html" title="Tages-Tickets">Tages-Tickets</a> </li>
+                                        <li> <a href="/tickets/saisonpaesse-jahreskarten.html" title="Saisonpässe &amp; Jahreskarten">Saisonpässe &amp; Jahreskarten</a> </li>
+                                        <li> <a href="/tickets/gruppen.html" title="Gruppen">Gruppen</a> </li>
+                                        <li> <a href="/tickets/extras-alt/express-butler.html" title="Express Butler">Express Butler</a> </li>
+                                    </ul>
+                                    <ul>
+                                        <li class="title"> <a href="http://www.heidepark.wizard.gmbh" target="_blank" class="data" data-direction-hint="Du verlässt jetzt die offizielle Webseite des Heide Park Resort und wirst zu unserem Souvenir-Shop weitergeleitet. Unser Partner Wizard GmbH arbeitet mit einer eigenen Datenschutzerkärung, die Du dort einsehen und am Ende Deines Einkaufs bestätigen kannst."> Souvenir-Shop </a> </li>
+                                    </ul>
+                                </div>
+                                <div class="small-6 medium-4 columns hide-for-small-only">
+                                    <ul>
+                                        <li class="title"> Informationen </li>
+                                        <li> <a href="/infos/presse.html" title="Presse">Presse</a> </li>
+                                        <li> <a href="/infos/buspartner.html" title="Buspartner">Buspartner</a> </li>
+                                        <li> <a href="/infos/ueber-uns.html" title="Über uns">Über uns</a> </li>
+                                        <li> <a href="/jobs.html" title="Jobs">Jobs</a> </li>
+                                        <li> <a href="/infos/parkordnung.html" title="Parkordnung">Parkordnung</a> </li>
+                                        <li> <a href="/infos/agb.html" title="AGB">AGB</a> </li>
+                                        <li> <a href="/infos/cookies.html" title="Cookies">Cookies</a> </li>
+                                        <li> <a href="/infos/videoueberwachung.html" title="Videoüberwachung">Videoüberwachung</a> </li>
+                                        <li> <a href="/infos/datenschutz.html" title="Datenschutz">Datenschutz</a> </li>
+                                        <li> <a href="/infos/impressum.html" title="Impressum">Impressum</a> </li>
+                                    </ul>
+                                </div>
+                                <div class="small-6 medium-4 columns show-for-small-only">
+                                    <ul>
+                                        <li class="title"> Informationen </li>
+                                        <li> <a href="/infos/presse.html" title="Presse">Presse</a> </li>
+                                        <li> <a href="/infos/ueber-uns.html" title="Über uns">Über uns</a> </li>
+                                        <li> <a href="/alt-infos/karriere.html" title="Karriere">Karriere</a> </li>
+                                        <li> <a href="/infos/parkordnung.html" title="Parkordnung">Parkordnung</a> </li>
+                                        <li> <a href="/infos/agb.html" title="AGB">AGB</a> </li>
+                                        <li> <a href="/infos/cookies.html" title="Cookies">Cookies</a> </li>
+                                        <li> <a href="/infos/videoueberwachung.html" title="Videoüberwachung">Videoüberwachung</a> </li>
+                                        <li> <a href="/infos/datenschutz.html" title="Datenschutz">Datenschutz</a> </li>
+                                        <li> <a href="/infos/impressum.html" title="Impressum">Impressum</a> </li>
+                                    </ul>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </section>
+                <section class="legals clearfix">
+                    <div class="row small-only-text-center">
+                        <div class="medium-6 medium-push-6 columns">
+                            <ul class="icons inline-list">
+                                <li>
+                                    <a href="https://instagram.com/heideparkresort/" target="_blank" class="icon-instagram"></a>
+                                </li>
+                                <li>
+                                    <a href="https://www.facebook.com/HeideParkResort" target="_blank" class="icon-facebook"></a>
+                                </li>
+                                <li>
+                                    <a href="https://www.youtube.com/user/HeideParkResort" class="icon-youtube" target="_blank"></a>
+                                </li>
+                                <li>
+                                    <a href="/tripadvisor-bewertungen.html" class="icon-tripadvisor" target="_blank"></a>
+                                </li>
+                                <!--<li><span class="icon-holidaycheck"></span></li>-->
+                            </ul>
+                        </div>
+                        <div class="medium-6 medium-pull-6 columns">
+                            <p>* Tel.: 0,20€/Anruf aus dem Festnetz, Mobilfunk max. 0,60€/Anruf, Fax: 0,14€/Min aus dem Festnetz, Mobilfunk max. 0,42€/Min</p>
+                            <p> Drachenzähmen - Die Insel &copy; 2018 DreamWorks Animation LLC
+                                <br> TM & &copy; 2018 Columbia Pictures Industries, Inc. All Rights Reserved
+                                <br> Peppa Pig © Astley Baker Davies Ltd/Entertainment One UK Ltd 2003
+                                <br> &copy; Heide Park Resort 2019, alle Rechte vorbehalten. </p>
+                        </div>
+                    </div>
+                </section>
+            </footer>
+            <!-- End Footer -->
+            <script type="text/javascript" src="https://me-hpgermany.secure-cdn20.accesso.com/embed/accesso.js" data-accesso="l=de-de,autoscroll=false"></script>
+            <!-- Piwik -->
+            <!-- <script type="text/javascript"> var _spef = _spef || []; _spef.push(["enableLinkTracking"]); _spef.push(["trackPageView"]); _spef.push(['setCookieDomain', '*.heide-park.de']); (function () { var u = "//trck.spoteffects.net/analytics/"; _spef.push(['setTrackerUrl', u + 'piwik.php']); _spef.push(['setSiteId', 196]); var d = document, g = d.createElement("script"), s = d.getElementsByTagName("script")[0]; g.type = "text/javascript"; g.defer = true; g.async = true; g.src = u + "spef.min.js"; s.parentNode.insertBefore(g, s); })(); </script> -->
+            <!-- End Piwik Code -->
+            <script src='//d3c3cq33003psk.cloudfront.net/opentag-125707-2123077.js' async defer></script>
+            <!-- Hotjar Tracking Code for https://www.heide-park.de -->
+            <script>
+                (function(h, o, t, j, a, r) {
+                    h.hj = h.hj || function() {
+                        (h.hj.q = h.hj.q || []).push(arguments)
+                    };
+                    h._hjSettings = {
+                        hjid: 231190,
+                        hjsv: 5
+                    };
+                    a = o.getElementsByTagName('head')[0];
+                    r = o.createElement('script');
+                    r.async = 1;
+                    r.src = t + h._hjSettings.hjid + j + h._hjSettings.hjsv;
+                    a.appendChild(r);
+                })(window, document, '//static.hotjar.com/c/hotjar-', '.js?sv=');
+            </script>
+            <!-- Show Newsletter Popup if checked in BE -->
+            <div id="js-newsletter-modal-colossos" class="colossos_newsletter newsletter__modal reveal-modal" data-reveal aria-labelledby="modalTitle" aria-hidden="true" role="dialog">
+                <div class="page newsletter__modal__inner colossos">
+                    <div class="animationwrapper colossos">
+                        <div class="videowrapper">
+                            <video width="230" height="264" muted autoplay loop="1">
+                                <source src="/typo3conf/ext/p2p/Resources/Public/assets_dist/animation/ADJ-Collossos.mp4" type="video/mp4"> </video>
+                        </div>
+                    </div>
+                    <iframe class="iframe iframe--newsletter iframe--transp js-iframe-newsletter" data-src="/iframes/newsletter-colossos.html?calling_id=890" frameborder="0"></iframe>
+                </div> <a href="#" class="close-reveal-modal" aria-label="Close"><span>&#215;</span></a> </div>
+            <!-- Show Info Popup -->
+        </div>
+    </div>
+    <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js" type="text/javascript"></script>
+    <script src="/typo3conf/ext/p2p/Resources/Public/assets_dist/js/app.js?1566554732" type="text/javascript"></script>
+    <style>
+        img[src*="https://ad.doubleclick.net/ddm/activity/src=8274353"],
+        img[src*="https://secure.adnxs.com/px?"] {
+            position: absolute;
+        }
+    </style>
+</body>
+
+</html>

--- a/lib/mocks/heideParkWaitTimes.mock
+++ b/lib/mocks/heideParkWaitTimes.mock
@@ -1,0 +1,279 @@
+{
+   "attractions":{
+      "ridetimes_online":"true",
+      "time_entries":[
+         {
+            "alias":"wildwasserbahn",
+            "msg":"45 <small>Min.<\/small>",
+            "type":"time"
+         },
+         {
+            "alias":"indy_blitz",
+            "msg":"20 <small>Min.<\/small>",
+            "type":"time"
+         },
+         {
+            "alias":"western_riesenrad",
+            "msg":"10 <small>Min.<\/small>",
+            "type":"time"
+         },
+         {
+            "alias":"mountain_rafting",
+            "msg":"20 <small>Min.<\/small>",
+            "type":"time"
+         },
+         {
+            "alias":"panorama_turm",
+            "msg":"10 <small>Min.<\/small>",
+            "type":"time"
+         },
+         {
+            "alias":"monorail",
+            "msg":"20 <small>Min.<\/small>",
+            "type":"time"
+         },
+         {
+            "alias":"grottenblitz",
+            "msg":"10 <small>Min.<\/small>",
+            "type":"time"
+         },
+         {
+            "alias":"ghostbusters",
+            "msg":"10 <small>Min.<\/small>",
+            "type":"time"
+         },
+         {
+            "alias":"wasserflieger",
+            "msg":"20 <small>Min.<\/small>",
+            "type":"time"
+         },
+         {
+            "alias":"himmelstuermer",
+            "msg":"10 <small>Min.<\/small>",
+            "type":"time"
+         },
+         {
+            "alias":"wolkenspringer",
+            "msg":"10 <small>Min.<\/small>",
+            "type":"time"
+         },
+         {
+            "alias":"drachengrotte",
+            "msg":"10 <small>Min.<\/small>",
+            "type":"time"
+         },
+         {
+            "alias":"desert_race",
+            "msg":"20 <small>Min.<\/small>",
+            "type":"time"
+         },
+         {
+            "alias":"magic",
+            "msg":"10 <small>Min.<\/small>",
+            "type":"time"
+         },
+         {
+            "alias":"huracan",
+            "msg":"Geschlossen",
+            "type":"red"
+         },
+         {
+            "alias":"colossos",
+            "msg":"90 <small>Min.<\/small>",
+            "type":"time"
+         },
+         {
+            "alias":"breakdance",
+            "msg":"10 <small>Min.<\/small>",
+            "type":"time"
+         },
+         {
+            "alias":"la_ola",
+            "msg":"10 <small>Min.<\/small>",
+            "type":"time"
+         },
+         {
+            "alias":"limit",
+            "msg":"10 <small>Min.<\/small>",
+            "type":"time"
+         },
+         {
+            "alias":"bobbahn",
+            "msg":"10 <small>Min.<\/small>",
+            "type":"time"
+         },
+         {
+            "alias":"screamie",
+            "msg":"10 <small>Min.<\/small>",
+            "type":"time"
+         },
+         {
+            "alias":"scream",
+            "msg":"Geschlossen",
+            "type":"red"
+         },
+         {
+            "alias":"flug_der_daemonen",
+            "msg":"30 <small>Min.<\/small>",
+            "type":"time"
+         },
+         {
+            "alias":"krake",
+            "msg":"45 <small>Min.<\/small>",
+            "type":"time"
+         },
+         {
+            "alias":"panoramabahn",
+            "msg":"10 <small>Min.<\/small>",
+            "type":"time"
+         },
+         {
+            "alias":"kaeptns_toern",
+            "msg":"10 <small>Min.<\/small>",
+            "type":"time"
+         },
+         {
+            "alias":"topilaula_schlacht",
+            "msg":"10 <small>Min.<\/small>",
+            "type":"time"
+         },
+         {
+            "alias":"bounty",
+            "msg":"10 <small>Min.<\/small>",
+            "type":"time"
+         },
+         {
+            "alias":"flossfahrt",
+            "msg":"10 <small>Min.<\/small>",
+            "type":"time"
+         },
+         {
+            "alias":"oldtimer_rundkurs",
+            "msg":"10 <small>Min.<\/small>",
+            "type":"time"
+         },
+         {
+            "alias":"big_loop",
+            "msg":"10 <small>Min.<\/small>",
+            "type":"time"
+         }
+      ],
+      "message_entries":[
+         {
+            "alias":"piraten_arena",
+            "app_msg":"Besucht unser neues Aktionspektakel \u201eIm Auge des Drachens\u201c!"
+         },
+         {
+            "alias":"lady_moon",
+            "app_msg":"Wirbelnder Fahrspa\u00df f\u00fcr nervenstarke Abenteurer"
+         },
+         {
+            "alias":"huracan",
+            "app_msg":"Aufgrund eines notwendigen Teiletauschs ist unser Huracan derzeit leider au\u00dfer Betrieb. Wir bedauern dies sehr, werden unsere Attraktion aber nat\u00fcrlich so schnell wie m\u00f6glich wieder f\u00fcr Euch \u00f6ffnen, sobald das Ersatzteil geliefert und verbaut wurde. Unser Tipp f\u00fcr Familien: Erlebt eine wilde Fahrt durch den Wilden Westen mit Indy-Blitz oder eine spritzige Abk\u00fchlung im Mountain-Rafting."
+         },
+         {
+            "alias":"bobbahn",
+            "app_msg":"Das Fahrgesch\u00e4ft Bobbahn startet im April und Oktober witterungsbedingt ggf. etwas sp\u00e4ter."
+         }
+      ],
+      "static_msg":"<p><strong>Informationen zu unseren Attraktionen<\/strong><br><p>Die Fahrgesch\u00e4fte Bobbahn & Limit starten witterungsbedingt ggf. etwas sp\u00e4ter.<\/p>\n"
+   },
+   "catering":{
+      "ridetimes_online":"true",
+      "time_entries":[
+         {
+            "alias":"coffee_lounge",
+            "msg":"Von 09-19 Uhr",
+            "type":"yellow"
+         },
+         {
+            "alias":"colossos_snack",
+            "msg":"Von 11-18 Uhr",
+            "type":"yellow"
+         },
+         {
+            "alias":"heide_park_grill",
+            "msg":"Von 12-19 Uhr",
+            "type":"yellow"
+         },
+         {
+            "alias":"piratenburger",
+            "msg":"Von 11-18 Uhr",
+            "type":"yellow"
+         },
+         {
+            "alias":"mummels_kiosk",
+            "msg":"Von 11-18 Uhr",
+            "type":"yellow"
+         },
+         {
+            "alias":"pizza_scream",
+            "msg":"Von 11-17 Uhr",
+            "type":"yellow"
+         },
+         {
+            "alias":"wirtshaus_des_admirals",
+            "msg":"Von 10-17 Uhr",
+            "type":"yellow"
+         },
+         {
+            "alias":"pizza_pasta",
+            "msg":"Von 12-17 Uhr",
+            "type":"yellow"
+         },
+         {
+            "alias":"mucho_pollo",
+            "msg":"Von 11-18 Uhr",
+            "type":"yellow"
+         },
+         {
+            "alias":"hot_dog",
+            "msg":"Von 11-17 Uhr",
+            "type":"yellow"
+         }
+      ]
+   },
+   "todaybox":{
+      "hours":"<p>\n <strong>Park<\/strong>\n <br>10:00 Uhr bis 19:00 Uhr<\/p>\n <hr>\n <p>\n <strong>Attraktionen<\/strong>\n <br>10:00 Uhr bis 18:00 Uhr<\/p>\n \n <p>\n <a href=\"https:\/\/www.heide-park.de\/infos\/oeffnungszeiten-anreise.html\">weitere \u00d6ffnungszeiten<\/a>\n <\/p>",
+      "catering":"<p><strong>Abenteurer Coffee Lounge<\/strong><br>09:00 Uhr bis 19:00 Uhr<\/p><hr><p><strong>Colossos Snack<\/strong><br>11:00 Uhr bis 18:00 Uhr<\/p><hr><p><strong>Heide Park Grill<\/strong><br>12:00 Uhr bis 19:00 Uhr<\/p><hr><p><strong>Piratenburger<\/strong><br>11:00 Uhr bis 18:00 Uhr<\/p><hr><p><strong>Frau M\u00fcmmels Kiosk<\/strong><br>11:00 Uhr bis 18:00 Uhr<\/p><hr><p><strong>Pizza Scream<\/strong><br>11:00 Uhr bis 17:00 Uhr<\/p><hr><p><strong>Wirtshaus d. Admirals<\/strong><br>10:00 Uhr bis 17:00 Uhr<\/p><hr><p><strong>Pizza & Pasta<\/strong><br>12:00 Uhr bis 17:00 Uhr<\/p><hr><p><strong>Mucho Pollo<\/strong><br>11:00 Uhr bis 18:00 Uhr<\/p><hr><p><strong>Hot Dog Freestyle<\/strong><br>11:00 Uhr bis 17:00 Uhr<\/p>",
+      "shows":"<p><strong>Im Auge des Drachens (Piraten-Arena)<\/strong><br>17:00 Uhr<\/p><hr><p><strong>Sandmaler (Show-Zelt)<\/strong><br>13:30 Uhr<\/p><hr><p><strong>Triff Peppa & Schorsch<\/strong><br>12:00 und 12:45 Uhr<\/p><hr><p><strong>Triff Ohnezahn<\/strong><br>13:00 Uhr<\/p><hr><p><strong>Die Traumf\u00e4nger (Show-Zelt)<\/strong><br>15:00 Uhr<\/p>",
+      "events":[
+         {
+            "event_title":"Zombie Escape",
+            "event_body":"<p>Versehentlich wurde ein Virus freigesetzt, der alle zu Zombies mutieren l\u00e4sst. Es werden immer mehr! Nur ein Code kann den Virus neutralisieren. Eure Mission, wenn Ihr euch traut: In Teams von 6 bis 8 Personen werdet Ihr in die Sperrzone eingeschleust. Aber Achtung, \u00fcberall lauern die Zombies, die alles daran setzen werden Euch daran zu hindern. Seid Ihr bereit?&nbsp;(ab 16 Jahren)<\/p><br \/>\n<br \/>\n<p>Event-Tage \u2013 jetzt planen und nichts verpassen: 8. &amp; 15. Juni, 31. August, sowie am 07. September<\/p>",
+            "event_link":"",
+            "event_teaser_img":"https:\/\/www.heide-park.de\/fileadmin\/_processed_\/b\/5\/csm_Vorlage_Events-Banner-zombie_Neu_1c9f6fef03.jpg",
+            "event_images":[
+               "https:\/\/www.heide-park.de\/fileadmin\/_processed_\/b\/1\/csm_Zombie_Escape_Logo_RGB_d246982b5f.jpg"
+            ]
+         },
+         {
+            "event_title":"XXL-Sommertage",
+            "event_body":"<p>Im Sommer hei\u00dft es f\u00fcr Dich und Deine Liebsten: Extra lange \u00d6ffnungszeiten = extra lange Achterbahn fahren<br\/> An den folgenden Samstagen haben wir bis 21 Uhr (Fahrgesch\u00e4fte bis 20 Uhr) f\u00fcr Euch ge\u00f6ffnet: <strong>20. Juli, 27. Juli, 03. August<\/strong><\/p><br \/>\n<br \/>\n<p><br\/> Freu' Dich auf extra langen Freizeitpark-Spa\u00df bei uns im Heide Park Resort!<\/p>",
+            "event_link":"",
+            "event_teaser_img":"https:\/\/www.heide-park.de\/fileadmin\/_processed_\/8\/0\/csm_Banner_XXL-Sommer_3_791f128dec.jpg",
+            "event_images":[
+               "https:\/\/www.heide-park.de\/fileadmin\/_processed_\/4\/1\/csm_Heide_Park_Resort_Colossos_001_cc23fed356.jpg"
+            ]
+         },
+         {
+            "event_title":"Pyro Games",
+            "event_body":"<p>Auch in diesem Jahr wird das Team der \"Pyro Games\" den Abendhimmel \u00fcber dem Heide Park Resort am <strong>31.08.<\/strong> mit Feuerwerk und farbenfrohen Laserstrahlen zum Leuchten bringen.<br\/> Die Kombination von Musik und Feuerwerk geht unter die Haut. Die eigens f\u00fcr diesen Abend gestalteten, musiksynchronen Feuerwerke beeindrucken durch Farbenpracht und Vielseitigkeit. Goldregen wird vom Abendhimmel herab regnen, lodernde Flammen und Feuerkreise den Sternenhimmel mit eindrucksvollen Bildern verzieren.&nbsp;<\/p>",
+            "event_link":"",
+            "event_teaser_img":"https:\/\/www.heide-park.de\/fileadmin\/_processed_\/e\/b\/csm_Vorlage_Events-Banner-pyrogames_43d5f1d824.jpg",
+            "event_images":[
+               "https:\/\/www.heide-park.de\/fileadmin\/_processed_\/a\/0\/csm_Pyro10_b19d37985c.jpg"
+            ]
+         },
+         {
+            "event_title":"Halloween 2019",
+            "event_body":"<p>2019 feiert das Heide Park Resort im gesamten Oktober Halloween!<br\/> An 6 Terminen (alle Samstage sowie der <strong>3. und 31.10.<\/strong>) erlebt Ihr Halloween-Spa\u00df bis 22 Uhr (Fahrgesch\u00e4fte bis 21 Uhr), u.a. mit 3 Horror-Attraktionen, Achterbahn-Fahren im Dunkeln und gro\u00dfem Feuerwerk.<br\/> An 22 weiteren Tagen gibt es ein Halloween-Programm f\u00fcr Familien mit Kindern und alle, die in den Ferien schaurig-sch\u00f6ne Halloween-Atmosph\u00e4re erleben m\u00f6chten. Der Park bleibt bis 18 bzw. 19 Uhr ge\u00f6ffnet, die Fahrgesch\u00e4fte schlie\u00dfen jeweils eine Stunde fr\u00fcher.<\/p>",
+            "event_link":"",
+            "event_teaser_img":"https:\/\/www.heide-park.de\/fileadmin\/_processed_\/e\/2\/csm_Vorlage_Events-Banner-halloween_eafb4332db.jpg",
+            "event_images":[
+               "https:\/\/www.heide-park.de\/fileadmin\/_processed_\/1\/b\/csm_NSF_1754_0e874103e1.jpg"
+            ]
+         }
+      ]
+   }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,15 +10,6 @@
       "integrity": "sha512-E5BN68cqR7dhKan1SfqgPGhQ178bkVKpXTPEXnFJBrEt8/DKRZlybmy+IgYLTeN7tp1R5Ccmbm2rBk17sHYU3g==",
       "dev": true
     },
-    "@types/moment": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@types/moment/-/moment-2.13.0.tgz",
-      "integrity": "sha1-YE69GJvDvDShVIaJQE5hoqSqyJY=",
-      "dev": true,
-      "requires": {
-        "moment": "*"
-      }
-    },
     "@types/node": {
       "version": "9.4.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-9.4.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,15 @@
       "integrity": "sha512-E5BN68cqR7dhKan1SfqgPGhQ178bkVKpXTPEXnFJBrEt8/DKRZlybmy+IgYLTeN7tp1R5Ccmbm2rBk17sHYU3g==",
       "dev": true
     },
+    "@types/moment": {
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/@types/moment/-/moment-2.13.0.tgz",
+      "integrity": "sha1-YE69GJvDvDShVIaJQE5hoqSqyJY=",
+      "dev": true,
+      "requires": {
+        "moment": "*"
+      }
+    },
     "@types/node": {
       "version": "9.4.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-9.4.0.tgz",


### PR DESCRIPTION
I added the Heidepark API.

This is my first pull-request, please let me know if something is not as you wish :)

All tests and linting passed so far.

Some information about the api and how i implemented it:

Openingtimes:
The API doesent provide the Openingtimes and the App also redirects you to the mobile website. Now the whole calendar page ist parsed by cheerio. I hope this is ok but i know this will generate some work in the future maybe, when Heidepark desides to change their webpage.

Catering:
The API provides opening hours for their restaurants and snack bars via the API, i added it to the waittimes and added the openinghours to the meta property because i didnt know where to provide it. Let me know if theres a better place for that

Special Events:
The API provides some information on upcoming special events (only in german as far as i saw it). I also added it to the waittimes with the information at the metadata. same as for catering: let me know if i should change that.

Fastpass:
There is a small text on their website where they list their fastpass rides. I hardcoded that Information and hope this is ok, but let me know if not :)

My VS Code did some changes to the readme ( i think because of a markdown plugin i use) i hope this is not a problem but i can revert this :)
