### PR TITLE
Uses operatings to get the operating status for Tokyo rides.

### DIFF
--- a/lib/disneytokyo/disneyTokyoBase.js
+++ b/lib/disneytokyo/disneyTokyoBase.js
@@ -166,6 +166,22 @@ class DisneyTokyoPark extends Park {
 
         rideData.FastPass = rides[ride.id].fastpass;
 
+        // For older API versions, operating status was a top-level field.
+        // In newer (1.0.16+) versions, it's in an "operatings" array, which
+        // only seems to have a single element for now. We'll handle either for
+        // backwards compatibility.
+        let status = ride.operatingStatus;
+        if (!status && ride.operatings && ride.operatings.length) {
+          if (ride.operatings.length > 1) {
+            // While there's a startAt/endAt timestamp pair in the operatings
+            // message, the times appear to be inconsistent with actual operating
+            // hours, and no evidence that multiple are ever sent, so we'll
+            // prefer the first one.
+            this.Log(`Found multiple operating messages for ${rides[ride.id].name}. Using the first one.`);
+          }
+          status = ride.operatings[0].operatingStatus;
+        }
+
         if (ride.operatingStatus === 'CLOSE_NOTICE') {
           // ride is temporarily closed
           rideData.waitTime = -2;


### PR DESCRIPTION
Fixes all Tokyo Disney rides coming back as CLOSED (https://github.com/cubehouse/themeparks/issues/231) by adding a fallback for operating status that uses the new "operatings" message in more recent API versions for status.