### PR TITLE
Fix API URL for Universal Studios Japan

### DIFF
--- a/lib/universal/universalstudiosjapan.js
+++ b/lib/universal/universalstudiosjapan.js
@@ -130,7 +130,7 @@ class UniversalStudiosJapan extends Park {
     // inherit from base class
     super(options);
 
-    this[sParkURL] = options.parkUrl || 'http://ar02.biglobe.ne.jp/app/waittime/waittime.json';
+    this[sParkURL] = options.parkUrl || 'https://spap.usj.co.jp/app/waittime/waittime.json';
     this[sParkCalendarURLBase] = options.parkCalendarURL || 'https://www.usj.co.jp/e/parkguide/';
   }
 


### PR DESCRIPTION
* Changed to https://spap.usj.co.jp