### PR TITLE
Fix mystery rides in Disney Paris parks

### DIFF
--- a/lib/disneyparis/disneyparisbase.js
+++ b/lib/disneyparis/disneyparisbase.js
@@ -115,47 +115,50 @@ class DisneyParisPark extends Park {
         times.forEach((time) => {
           const rideData = parkData[time.entityId] || {};
 
-          const RideUpdateObject = {
-            name: rideData.name || '???',
-            meta: {},
-          };
+          // must have a valid name to be returned as a valid ride
+          if (rideData.name) {
+            const RideUpdateObject = {
+              name: rideData.name,
+              meta: {},
+            };
 
-          // figure out wait time
-          if (time.status === 'OPERATING') {
-            RideUpdateObject.waitTime = parseInt(time.postedWaitMinutes || 0, 10) || 0;
-          } else if (time.status === 'DOWN') {
-            RideUpdateObject.waitTime = -2;
-          } else if (rideData.active !== undefined && !rideData.active) {
-            // use ride data to determine if ride is under refurb or closed
-            if (rideData.status === 'REFURBISHMENT') {
-              RideUpdateObject.waitTime = -3; // refurb
-            } else if (rideData.status === 'CLOSED') {
-              RideUpdateObject.waitTime = -1; // closed
+            // figure out wait time
+            if (time.status === 'OPERATING') {
+              RideUpdateObject.waitTime = parseInt(time.postedWaitMinutes || 0, 10) || 0;
+            } else if (time.status === 'DOWN') {
+              RideUpdateObject.waitTime = -2;
+            } else if (rideData.active !== undefined && !rideData.active) {
+              // use ride data to determine if ride is under refurb or closed
+              if (rideData.status === 'REFURBISHMENT') {
+                RideUpdateObject.waitTime = -3; // refurb
+              } else if (rideData.status === 'CLOSED') {
+                RideUpdateObject.waitTime = -1; // closed
+              }
+            } else {
+              // unknown status, assume closed
+              RideUpdateObject.waitTime = -1;
             }
-          } else {
-            // unknown status, assume closed
-            RideUpdateObject.waitTime = -1;
-          }
 
-          // add opening/closing times (if available)
-          if (rideData.openingTime && rideData.closingTime) {
-            RideUpdateObject.meta.rideOpeningTime = Moment.tz(rideData.openingTime, 'YYYY-MM-DDTHH:mm:ss', this.Timezone).format();
-            RideUpdateObject.meta.rideClosingTime = Moment.tz(rideData.closingTime, 'YYYY-MM-DDTHH:mm:ss', this.Timezone).format();
-          }
+            // add opening/closing times (if available)
+            if (rideData.openingTime && rideData.closingTime) {
+              RideUpdateObject.meta.rideOpeningTime = Moment.tz(rideData.openingTime, 'YYYY-MM-DDTHH:mm:ss', this.Timezone).format();
+              RideUpdateObject.meta.rideClosingTime = Moment.tz(rideData.closingTime, 'YYYY-MM-DDTHH:mm:ss', this.Timezone).format();
+            }
 
-          // add single ride status (if available)
-          if (time.singleRider && time.singleRider.isAvailable) {
-            RideUpdateObject.meta.singleRider = true;
-            RideUpdateObject.meta.singleRiderWaitTime = parseInt(time.singleRider.singleRiderWaitMinutes || 0, 10) || 0;
-          } else {
-            RideUpdateObject.meta.singleRider = false;
-          }
+            // add single ride status (if available)
+            if (time.singleRider && time.singleRider.isAvailable) {
+              RideUpdateObject.meta.singleRider = true;
+              RideUpdateObject.meta.singleRiderWaitTime = parseInt(time.singleRider.singleRiderWaitMinutes || 0, 10) || 0;
+            } else {
+              RideUpdateObject.meta.singleRider = false;
+            }
 
-          waitTimeObjects.push({
-            id: time.entityId,
-            park: time.parkId,
-            data: RideUpdateObject,
-          });
+            waitTimeObjects.push({
+              id: time.entityId,
+              park: time.parkId,
+              data: RideUpdateObject,
+            });
+          }
         });
 
         return Promise.resolve(waitTimeObjects);


### PR DESCRIPTION
* Don't return invalid "non-rides" with no name

Some rides are returning "???" for their names. These are meet & greets and other non-rides that don't show up properly. We were ignoring these before Disney Paris switched their API, so am returning to ignore them again.