### PR TITLE
Fix JSON parsing error in some environments

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -149,7 +149,7 @@ function MakeRequest(networkRequest) {
             }
 
             // if we want to force JSON (and we're not already a JSON object!)
-            if (forceJSON && resp.body.constructor !== {}.constructor && resp.body.constructor !== [].constructor) {
+            if (forceJSON && resp.body.constructor.name !== {}.constructor.name && resp.body.constructor.name !== [].constructor.name) {
               let JSONData;
               try {
                 JSONData = JSON.parse(resp.body);


### PR DESCRIPTION
* Sometimes detecting Object/Array doesn't work
* Detect based on constructor name instead, rather than direct pointer to the constructor

Observed when including themeparks in the NodeJS VM.