### PR TITLE
Add fetching meta information for fastpass in Tokyo

### DIFF
--- a/lib/disneytokyo/disneyTokyoBase.js
+++ b/lib/disneytokyo/disneyTokyoBase.js
@@ -164,17 +164,15 @@ class DisneyTokyoPark extends Park {
           name: rides[ride.id].name,
           meta: {
             facilityCode: rides[ride.id].facilityCode,
-            // Add properties for fastpass
-            fastPassStartTime: null,
-            fastPassEndTime: null,
-            fastPassStatus: null,
           },
         };
 
         rideData.FastPass = rides[ride.id].fastpass;
         if (rides[ride.id].fastpass) {
-          rideData.meta.fastPassStartTime = ride.fastPassStartDateTime;
-          rideData.meta.fastPassEndTime = ride.fastPassEndDateTime;
+          if (ride.fastPassStatus === 'TICKETING') {
+            rideData.meta.fastPassStartTime = `${ride.fastPassStartAt}:00`;
+            rideData.meta.fastPassEndTime = `${ride.fastPassEndAt}:00`;
+          }
           rideData.meta.fastPassStatus = ride.fastPassStatus;
         }
 

--- a/lib/disneytokyo/disneyTokyoBase.js
+++ b/lib/disneytokyo/disneyTokyoBase.js
@@ -164,10 +164,19 @@ class DisneyTokyoPark extends Park {
           name: rides[ride.id].name,
           meta: {
             facilityCode: rides[ride.id].facilityCode,
+            // Add properties for fastpass
+            fastPassStartTime: null,
+            fastPassEndTime: null,
+            fastPassStatus: null,
           },
         };
 
         rideData.FastPass = rides[ride.id].fastpass;
+        if (rides[ride.id].fastpass) {
+          rideData.meta.fastPassStartTime = ride.fastPassStartDateTime;
+          rideData.meta.fastPassEndTime = ride.fastPassEndDateTime;
+          rideData.meta.fastPassStatus = ride.fastPassStatus;
+        }
 
         // For older API versions, operating status was a top-level field.
         // In newer (1.0.16+) versions, it's in an "operatings" array, which
@@ -236,7 +245,7 @@ class DisneyTokyoPark extends Park {
             rideData[attr.id] = {
               name: englishData && englishData.name !== undefined ? englishData.name : attr.nameKana,
               fastpass: !!attr.fastpass,
-              type: attr.attractionType.id,
+              type: attr.attractionType !== undefined ? attr.attractionType.id : 1,
               facilityCode: Number(attr.facilityCode),
             };
           });


### PR DESCRIPTION
Hi.
I improved so that DisneyTokyoPark.FetchWaitTimes() can get meta information for fastpass.

Meta information added is as follows:
- fastPassStartTime: start time of using fastpass (HH:MM:SS at localtime)
- fastPassEndTime: end time of using fastpass (HH:MM:SS at localtime)
- fastPassStatus: status of fastpass ticketing.[ TICKETING or TICKETING_END]

And, I also fixed DisneyTokyoPark.FetchWaitTimes() to be fail-safe because sometimes there is no attractionType on a special day.(ex. Mickey's birthday)