### PR TITLE
Bugfix/issue 269 phantasialand openingtimes

### DIFF
--- a/lib/phantasialand/phantasialand.js
+++ b/lib/phantasialand/phantasialand.js
@@ -128,7 +128,7 @@ class Phantasialand extends Park {
       mock: 'phantasialand_calendarHTML',
     }).then((html) => {
       const $ = cheerio.load(html);
-      const timeRegex = /(?:\+)(\d*%3A\d*)(?:\+)/g;
+      const timeRegex = /(\d*%3A\d*)/g;
       const calendarData = JSON.parse($('.phl-date-picker').attr('data-calendar'));
       calendarData.forEach((timeseries) => {
         const timesMatch = timeseries.title.match(timeRegex);
@@ -136,8 +136,8 @@ class Phantasialand extends Park {
           this.Schedule.SetRange({
             startDate: Moment.tz(timeseries.startDate, 'YYYY-MM-DD', this.Timezone),
             endDate: Moment.tz(timeseries.endDate, 'YYYY-MM-DD', this.Timezone),
-            openingTime: Moment.tz(timesMatch[0].replace('%3A', ':').replace('+', ''), 'HH:mm', this.Timezone),
-            closingTime: Moment.tz(timesMatch[1].replace('%3A', ':').replace('+', ''), 'HH:mm', this.Timezone),
+            openingTime: Moment.tz(timesMatch[0].replace('%3A', ':'), 'HH:mm', this.Timezone),
+            closingTime: Moment.tz(timesMatch[1].replace('%3A', ':'), 'HH:mm', this.Timezone),
           });
         } else {
           this.Schedule.SetRange({

--- a/lib/phantasialand/phantasialand.js
+++ b/lib/phantasialand/phantasialand.js
@@ -128,7 +128,7 @@ class Phantasialand extends Park {
       mock: 'phantasialand_calendarHTML',
     }).then((html) => {
       const $ = cheerio.load(html);
-      const timeRegex = /(\d*%3A\d*)/g;
+      const timeRegex = /(\d+%3A\d+)/g;
       const calendarData = JSON.parse($('.phl-date-picker').attr('data-calendar'));
       calendarData.forEach((timeseries) => {
         const timesMatch = timeseries.title.match(timeRegex);


### PR DESCRIPTION
- I changed the time regex to match opening times like "10%3A00+Uhr+bis+19%3A00+Uhr"
and times with special information like "Wintertraum%3A+11%3A00+bis+20%3A00+Uhr".
- Removed the unnecessary "plus" parts from the regex.

Related to Issue #269