### PR TITLE
Add virtual line times to Universal

### DIFF
--- a/lib/universal/universalislandsofadventure.js
+++ b/lib/universal/universalislandsofadventure.js
@@ -20,6 +20,10 @@ class UniversalIslandsOfAdventure extends UniversalPark {
     // Univesral park ID
     options.parkId = options.parkId || 10000;
 
+    options.parkCity = 'Orlando';
+
+    options.virtualLineTimes = true;
+
     // inherit from base class
     super(options);
   }

--- a/lib/universal/universalparkbase.js
+++ b/lib/universal/universalparkbase.js
@@ -240,8 +240,8 @@ class UniversalPark extends Park {
             if (virtualLines[ride.Id]) {
               virtualLines[ride.Id].AppointmentTimes.forEach((appointment) => {
                 metadata.virtualLineAvailableTimes.push({
-                  start: Moment.tz(appointment.StartTime, 'YYYY-MM-DDTHH:mm:ssZ', this.Timezone),
-                  end: Moment.tz(appointment.EndTime, 'YYYY-MM-DDTHH:mm:ssZ', this.Timezone),
+                  start: appointment.StartTime,
+                  end: appointment.EndTime,
                 })
               });
             }

--- a/lib/universal/universalparkbase.js
+++ b/lib/universal/universalparkbase.js
@@ -12,6 +12,7 @@ const apiAppSecret = 'AndroidMobileAppSecretKey182014';
 
 const sParkID = Symbol('Park ID');
 const sCity = Symbol('City ID');
+const sVirtualLineTimes = Symbol('Load Virtual Lines');
 
 // park IDs:
 //  Studios: 10010
@@ -46,6 +47,9 @@ class UniversalPark extends Park {
 
     // universal hollywood uses ?city= on it's API requests, so optionally support setting that
     this[sCity] = options.parkCity;
+
+    // load available virtual lines times with wait times
+    this[sVirtualLineTimes] = options.virtualLineTimes;
   }
 
   // override Fastpass Getter to declare support for FastPass
@@ -142,14 +146,43 @@ class UniversalPark extends Park {
    * @returns {Promise}
    */
   FetchWaitTimes() {
-    // ride wait time data is kept in the pointsOfInterest URL
-    return this.GetAPIUrl({
-      url: `${apiBaseURL}pointsOfInterest`,
-      data: this[sCity] ? {
-        city: this[sCity],
-      } : null,
-    }).then((body) => {
+    // Get current date for virtual lines
+    let currently = Moment.tz(this.Timezone);
+
+    let requests = [
+      // ride wait time data is kept in the pointsOfInterest URL
+      this.GetAPIUrl({
+        url: `${apiBaseURL}pointsOfInterest`,
+        data: this[sCity] ? {
+          city: this[sCity],
+        } : null,
+      })
+    ];
+
+    // Virtual lines require city to be set
+    if (this[sVirtualLineTimes] && this[sCity]) {
+      requests.push(
+        this.GetAPIUrl({
+          url: `${apiBaseURL}AdditionalAppts/QueuesWithAppointments`,
+          data: {
+            city: this[sCity],
+            page: 1,
+            pageSize: 'all',
+            appTimeForToday: currently.format('MM/DD/YYYY'),
+          },
+        })
+      );
+    }
+
+    return Promise.all(requests).then(([body, virtualLinesBody]) => {
       if (!body || !body.Rides) return Promise.reject(new Error('Universal POI data missing Rides array'));
+
+      let virtualLines = {};
+      if (virtualLinesBody) {
+        virtualLinesBody.Results.forEach((virtualLine) => {
+          virtualLines[virtualLine.QueueEntityId] = virtualLine;
+        });
+      }
 
       body.Rides.forEach((ride) => {
         // skip if this ride isn't for our current park
@@ -194,16 +227,31 @@ class UniversalPark extends Park {
               waitTime = ride.WaitTime;
           }
 
+          let metadata = {
+            latitude: ride.Latitude,
+            longitude: ride.Longitude,
+            virtualLine: ride.VirtualLine || false,
+            singleRider: ride.HasSingleRiderLine || false,
+          };
+
+          if (this[sVirtualLineTimes] && metadata.virtualLine) {
+            metadata.virtualLineAvailableTimes = [];
+
+            if (virtualLines[ride.Id]) {
+              virtualLines[ride.Id].AppointmentTimes.forEach((appointment) => {
+                metadata.virtualLineAvailableTimes.push({
+                  start: Moment.tz(appointment.StartTime, 'YYYY-MM-DDTHH:mm:ssZ', this.Timezone),
+                  end: Moment.tz(appointment.EndTime, 'YYYY-MM-DDTHH:mm:ssZ', this.Timezone),
+                })
+              });
+            }
+          }
+
           this.UpdateRide(ride.Id, {
             name: ride.MblDisplayName,
             waitTime,
             fastPass: ride.ExpressPassAccepted,
-            meta: {
-              latitude: ride.Latitude,
-              longitude: ride.Longitude,
-              virtualLine: ride.VirtualLine || false,
-              singleRider: ride.HasSingleRiderLine || false,
-            },
+            meta: metadata,
           });
         }
       });

--- a/lib/universal/universalstudiosflorida.js
+++ b/lib/universal/universalstudiosflorida.js
@@ -20,6 +20,12 @@ class UniversalStudiosFlorida extends UniversalPark {
     // Univesral park ID
     options.parkId = options.parkId || 10010;
 
+    // City name required for virtual lines
+    options.parkCity = 'Orlando';
+
+    // Turn on virtual line times
+    options.virtualLineTimes = true;
+
     // inherit from base class
     super(options);
   }


### PR DESCRIPTION
Addresses #291 

Due to social distancing rules, Universal has increased their usage of their virtual line system. It's a similar system to Disney's FastPass+, where you're given the option of multiple "appointments" you can book. Since it's not exactly FastPass, and the fastPass object is used to denote what rides have Express, I simply added the available times via the metadata. Universal supplies a bunch of internal capacity related data with each appointment, but really all we need to know is what the start & end time is for each appointment.

I would think Hollywood will implement a similar system, so I kept that in mind and we can turn on support for Hollywood with a simple option if they do.

I worked on this after-hours, so I'll need to wait until tomorrow to see if the data populates correctly. Once it does, I'll supply an example ride object with the new array.