### PR TITLE
fix(disney): updating needle headers to properly connect to couchbase

### DIFF
--- a/lib/disney/couchbaseChannel.js
+++ b/lib/disney/couchbaseChannel.js
@@ -234,7 +234,7 @@ class CouchbaseChannel extends EventEmitter {
   get HTTPHeaders() {
     return {
       Authorization: this[sAuthHeader] || null,
-      'User-Agent': CouchbaseLiteUserAgent,
+      user_agent: CouchbaseLiteUserAgent,
     };
   }
 

--- a/lib/disney/couchbaseChannel.js
+++ b/lib/disney/couchbaseChannel.js
@@ -234,7 +234,9 @@ class CouchbaseChannel extends EventEmitter {
   get HTTPHeaders() {
     return {
       Authorization: this[sAuthHeader] || null,
-      user_agent: CouchbaseLiteUserAgent,
+      'User-Agent': CouchbaseLiteUserAgent,
+      Connection: 'Keep-Alive',
+      'Accept-Encoding': 'gzip, deflate, br',
     };
   }
 


### PR DESCRIPTION
Addressing issue #314 

The user_agent HTTPHeader value seems to be the proper property to assign as per needle's documentation ([here](https://github.com/tomas/needle/tree/master#http-header-options))