### PR TITLE
fix(universal): properly pass token ttl to cache

### DIFF
--- a/lib/universal/universalparkbase.js
+++ b/lib/universal/universalparkbase.js
@@ -113,7 +113,7 @@ class UniversalPark extends Park {
           return Promise.reject(new Error(err));
         }
       );
-    }, receivedTtl);
+    }, () => Promise.resolve(receivedTtl));
   }
 
   /**


### PR DESCRIPTION
Pass the received access token TTL to the Cache.Wrap function through a lambda to capture value reference.

Closes #304