### PR TITLE
Fix "Cannot read property 'date' of null" errors w/ GetOpeningTimes

### DIFF
--- a/lib/hostedPark.js
+++ b/lib/hostedPark.js
@@ -26,6 +26,8 @@ class HostedPark extends Park {
       url: `https://api.themeparks.wiki/preview/parks/${this.ParkAPIID}/calendar`,
     }).then((data) => {
       data.forEach((date) => {
+        if (!date) return;
+        
         this.Schedule.SetDate({
           date: Moment(date.date).tz(this.Timezone),
           openingTime: Moment(date.openingTime).tz(this.Timezone),


### PR DESCRIPTION
When using the GetOpeningTimes method, there is a chance that the calendar endpoint will [give us back a value of null for certain days](https://pastebin.com/SgDPFUw1), so during each iteration we check that the date actually exists, if not, we skip over it. 

The pattern I am seeing that any dates before the current (todays) date are marked as `null` in the calendar endpoint, only future dates are displayed.