### PR TITLE
Readd Support for Heidepark as of #281

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ You can change some settings of the library by editing the properties of the `Th
 | CacheOpeningTimesLength | 1 hour                           | Time to cache opening times (in seconds)     |
 
 ## Example Use
-
+```javascript
     // include the Themeparks library
     const Themeparks = require("themeparks");
 
@@ -61,9 +61,9 @@ You can change some settings of the library by editing the properties of the `Th
     CheckWaitTimes();
 
     // you can also call GetOpeningTimes on themeparks objects to get park opening hours
-
+```
 ### Proxy
-
+```javascript
 If you wish to use themeparks with a proxy, you can pass a proxy agent when you construct the park object.
 
     // include the Themeparks library
@@ -79,7 +79,7 @@ If you wish to use themeparks with a proxy, you can pass a proxy agent when you 
     const DisneyWorldMagicKingdom = new Themeparks.Parks.WaltDisneyWorldMagicKingdom({
         proxyAgent: MyProxy
     });
-
+```
 ## Change Log
 
 [View themeparks Change Log](CHANGELOG.md)
@@ -228,7 +228,7 @@ If you wish to use themeparks with a proxy, you can pass a proxy agent when you 
 ## Result Objects
 
 ### Ride Wait Times
-
+```
     [
         {
             id: (string or number: uniquely identifying a ride),
@@ -260,9 +260,9 @@ If you wish to use themeparks with a proxy, you can pass a proxy agent when you 
         },
         ...
     ]
-
+```
 ### Schedules
-
+```
     [
         {
             date: (dateFormat timestamp: day this schedule applies),
@@ -277,7 +277,7 @@ If you wish to use themeparks with a proxy, you can pass a proxy agent when you 
         },
         ...
     ]
-
+```
 ## Park Object values
 
 There are some values available on each park object that may be useful.
@@ -294,7 +294,7 @@ There are some values available on each park object that may be useful.
 | FastPassReturnTimes   | Does this park tell you the FastPass return times?                                                          |
 | Now                   | Current date/time at this park (returned as a Moment object)                                                |
 | UserAgent             | The HTTP UserAgent this park is using to make API requests (usually randomly generated per-park at runtime) |
-
+```javascript
     const ThemeParks = require("themeparks");
 
     // construct our park objects and keep them in memory for fast access later
@@ -307,7 +307,7 @@ There are some values available on each park object that may be useful.
     for (const park in Parks) {
       console.log(`* ${Parks[park].Name} [${Parks[park].LocationString}]: (${Parks[park].Timezone})`);
     }
-
+```
 Prints:
 
 <!-- START_PARK_TIMEZONE_LIST -->

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ You can change some settings of the library by editing the properties of the `Th
 | CacheOpeningTimesLength | 1 hour                           | Time to cache opening times (in seconds)     |
 
 ## Example Use
-```javascript
+
     // include the Themeparks library
     const Themeparks = require("themeparks");
 
@@ -61,9 +61,9 @@ You can change some settings of the library by editing the properties of the `Th
     CheckWaitTimes();
 
     // you can also call GetOpeningTimes on themeparks objects to get park opening hours
-```
+
 ### Proxy
-```javascript
+
 If you wish to use themeparks with a proxy, you can pass a proxy agent when you construct the park object.
 
     // include the Themeparks library
@@ -79,7 +79,7 @@ If you wish to use themeparks with a proxy, you can pass a proxy agent when you 
     const DisneyWorldMagicKingdom = new Themeparks.Parks.WaltDisneyWorldMagicKingdom({
         proxyAgent: MyProxy
     });
-```
+
 ## Change Log
 
 [View themeparks Change Log](CHANGELOG.md)
@@ -228,7 +228,7 @@ If you wish to use themeparks with a proxy, you can pass a proxy agent when you 
 ## Result Objects
 
 ### Ride Wait Times
-```
+
     [
         {
             id: (string or number: uniquely identifying a ride),
@@ -260,9 +260,9 @@ If you wish to use themeparks with a proxy, you can pass a proxy agent when you 
         },
         ...
     ]
-```
+
 ### Schedules
-```
+
     [
         {
             date: (dateFormat timestamp: day this schedule applies),
@@ -277,7 +277,7 @@ If you wish to use themeparks with a proxy, you can pass a proxy agent when you 
         },
         ...
     ]
-```
+
 ## Park Object values
 
 There are some values available on each park object that may be useful.
@@ -294,7 +294,7 @@ There are some values available on each park object that may be useful.
 | FastPassReturnTimes   | Does this park tell you the FastPass return times?                                                          |
 | Now                   | Current date/time at this park (returned as a Moment object)                                                |
 | UserAgent             | The HTTP UserAgent this park is using to make API requests (usually randomly generated per-park at runtime) |
-```javascript
+
     const ThemeParks = require("themeparks");
 
     // construct our park objects and keep them in memory for fast access later
@@ -307,7 +307,7 @@ There are some values available on each park object that may be useful.
     for (const park in Parks) {
       console.log(`* ${Parks[park].Name} [${Parks[park].LocationString}]: (${Parks[park].Timezone})`);
     }
-```
+
 Prints:
 
 <!-- START_PARK_TIMEZONE_LIST -->

--- a/lib/heidepark/heidepark.js
+++ b/lib/heidepark/heidepark.js
@@ -11,7 +11,7 @@ const fastPassRides = [
   'krake',
   'desert_race',
   'scream',
-  'big_loop',
+  'big-loop',
   'limit',
   'bobbahn',
   'grottenblitz',
@@ -37,9 +37,9 @@ class HeidePark extends Park {
     super(options);
 
     // accept overriding the API base URL
-    this[sApiBase] = options.apiBase || 'https://www.heide-park.de/api/';
+    this[sApiBase] = options.apiBase || 'https://backend.heide-park.de';
     // accept overriding API version
-    this[sApiVersion] = options.apiVersion || 'v4';
+    this[sApiVersion] = options.apiVersion || 'v1';
   }
 
   get FastPass() {
@@ -48,7 +48,7 @@ class HeidePark extends Park {
 
   /** Convert a ride alias into a human-readable name */
   aliasToName(alias) {
-    return alias.split('_').map((word) => {
+    return alias.split('-').map((word) => {
       return word.substring(0, 1).toUpperCase() + word.substring(1);
     }).join(' ');
   }
@@ -59,37 +59,30 @@ class HeidePark extends Park {
    * @param {String} type The Type of the timeEntries 'ride' | 'catering
    */
   updateHeideParkTimeEntries(timeEntries) {
-    timeEntries.forEach((ride) => {
+    const timeEntriesKeys = Object.keys(timeEntries);
+    timeEntriesKeys.forEach((key) => {
+      const ride = timeEntries[key];
       const rideUpdate = {
         waitTime: -1,
         active: false,
         status: 'Closed',
-        name: ride.alias ? this.aliasToName(ride.alias) : '???',
-        fastPass: fastPassRides.indexOf(ride.alias ? ride.alias : '???') >= 0,
+        name: this.aliasToName(key),
+        fastPass: fastPassRides.includes(key),
       };
 
-      if (ride.type === 'red') {
-        // closed
-      } else if (ride.type === 'time') {
-        // waittime string in format "10 <small>Min.<\/small>"
-        const waittimeArr = ride.msg.match(/(^\d*)\s/);
-        rideUpdate.waitTime = waittimeArr ? parseInt(waittimeArr[1], 10) : 0;
-        rideUpdate.active = true;
-        rideUpdate.status = 'Operating';
-      }
-      this.UpdateRide(ride.alias.toLowerCase(), rideUpdate);
+      rideUpdate.waitTime = parseInt(ride.waiting_time, 10);
+      rideUpdate.active = ride.is_available;
+      rideUpdate.status = ride.is_available ? 'Operating' : 'Closed';
+
+      this.UpdateRide(key.toLowerCase(), rideUpdate);
     });
   }
 
   FetchWaitTimes() {
     return this.HTTP({
-      url: `${this[sApiBase]}${this[sApiVersion]}`,
-      returnFullResponse: true,
-      mock: 'heideParkWaitTimes',
+      url: `${this[sApiBase]}/${this[sApiVersion]}/dynamic?demo=1&token=33gTM5AjY5TqWeVsQA2SFcF3qaSvhjyT37q9GHqUtOCnUDpx0NvRuFcwKeMc`,
     }).then((parkData) => {
-      let result = parkData.body.replace(/^\(/, '');
-      result = JSON.parse(result.replace(/\);$/, ''));
-      this.updateHeideParkTimeEntries(result.attractions.time_entries, 'ride');
+      this.updateHeideParkTimeEntries(parkData.attractions, 'ride');
       return Promise.resolve();
     });
   }

--- a/lib/heidepark/heidepark.js
+++ b/lib/heidepark/heidepark.js
@@ -7,9 +7,9 @@ const sApiVersion = Symbol('Heide Park API Version');
 
 const fastPassRides = [
   'colossos',
-  'flug_der_daemonen',
+  'flug-der-daemonen',
   'krake',
-  'desert_race',
+  'desert-race',
   'scream',
   'big-loop',
   'limit',

--- a/lib/http.js
+++ b/lib/http.js
@@ -89,7 +89,7 @@ function MakeRequest(networkRequest) {
     if (!requestURL) return Promise.reject(new Error(`No URL defined for ${requestMethod} request`));
     delete options.url;
 
-    const requestData = options.data || options.body || {};
+    const requestData = options.data || options.body || null;
     delete options.data;
     delete options.body;
 
@@ -118,7 +118,6 @@ function MakeRequest(networkRequest) {
       // make request in an anonymous function so we can make multiple requests to it easily
       const attemptRequest = () => {
         Log(`Calling ${requestMethod}:${requestURL}`);
-
         // build Needle request
         needle.request(requestMethod, requestURL, requestData, options, (err, resp) => {
           if (err || resp.statusCode >= 400 || (resp.statusCode === 200 && !resp.body)) {


### PR DESCRIPTION
I changed the API used by heidepark.js as discussed in [#281](https://github.com/cubehouse/themeparks/issues/281).
I also had to change http.js to set the requestData to null if nether options.data or options.body are provided, as {} would result in an "unauthorised" error.
I improved the readme too, by adding code fencing to allow syntax highlighting, as this improves the readability.

(I hope, I did everything correct, as this is my first real PR ;)